### PR TITLE
[L12] Add pagination tables and printable annotations

### DIFF
--- a/docs/implementation/lots/L12-documentation.md
+++ b/docs/implementation/lots/L12-documentation.md
@@ -52,9 +52,9 @@ L12-S02 is split into S02a–S02h because the new request introduces real PDF be
 
 ### L12-S02c — `feat(pdf): add reusable pagination and table components`
 
-- [ ] KeepTogether, PageBreak, PageHeader, PageFooter, PageNumber, Table and DataTable.
-- [ ] Reuse flow-table helpers rather than maintaining separate invoice and component table engines.
-- [ ] Define repeated space, final page counts, row overflow and oversized-group handling explicitly.
+- [x] KeepTogether, PageBreak, PageHeader, PageFooter, PageNumber, Table and DataTable.
+- [x] Reuse flow-table helpers rather than maintaining separate invoice and component table engines.
+- [x] Define repeated space, final page counts, row overflow and oversized-group handling explicitly.
 
 **Acceptance:** A representative long table retains its first/last rows, repeating headers, final page count and summary without footer overlap.
 

--- a/docs/implementation/lots/L12-documentation.md
+++ b/docs/implementation/lots/L12-documentation.md
@@ -62,9 +62,9 @@ L12-S02 is split into S02a–S02h because the new request introduces real PDF be
 
 ### L12-S02d — `feat(pdf): add printable form and annotation components`
 
-- [ ] Alert, Badge, Form, Signature and Watermark with neutral defaults and explicit semantic labels.
-- [ ] Printable one/two/three-column fields, single/dual signer areas and controlled repeated watermark placement.
-- [ ] State that these are static document elements, not interactive AcroForms, cryptographic signatures or document protection.
+- [x] Alert, Badge, Form, Signature and Watermark with neutral defaults and explicit semantic labels.
+- [x] Printable one/two/three-column fields, single/dual signer areas and controlled repeated watermark placement.
+- [x] State that these are static document elements, not interactive AcroForms, cryptographic signatures or document protection.
 
 **Acceptance:** The shared specimen shows all five categories without missing labels or overlapping content.
 

--- a/docs/implementation/status.json
+++ b/docs/implementation/status.json
@@ -309,7 +309,8 @@
         "5f4e0538db6806c32aead4beb19ffd66f54e9da0",
         "06697e17ae68751df08bd4d880b82c7389399711",
         "a516c46b678aea25894c41a4a3fb31870f613653",
-        "0a9aeebaa2360f658cbd870e40187ab70c5dfac2"
+        "0a9aeebaa2360f658cbd870e40187ab70c5dfac2",
+        "f880d873d3cea7d23b78fff0c5eec1f8e5443ae3"
       ],
       "evidence": "../qa/L12.md",
       "blocker": null

--- a/docs/implementation/status.json
+++ b/docs/implementation/status.json
@@ -310,7 +310,8 @@
         "06697e17ae68751df08bd4d880b82c7389399711",
         "a516c46b678aea25894c41a4a3fb31870f613653",
         "0a9aeebaa2360f658cbd870e40187ab70c5dfac2",
-        "f880d873d3cea7d23b78fff0c5eec1f8e5443ae3"
+        "f880d873d3cea7d23b78fff0c5eec1f8e5443ae3",
+        "e824244fd6034afd493fdfac2954cf49cdbd9441"
       ],
       "evidence": "../qa/L12.md",
       "blocker": null

--- a/docs/implementation/status.json
+++ b/docs/implementation/status.json
@@ -312,7 +312,8 @@
         "0a9aeebaa2360f658cbd870e40187ab70c5dfac2",
         "f880d873d3cea7d23b78fff0c5eec1f8e5443ae3",
         "e824244fd6034afd493fdfac2954cf49cdbd9441",
-        "3cf96d4343c8a570e3340834f03902f00d9c83b3"
+        "3cf96d4343c8a570e3340834f03902f00d9c83b3",
+        "4c4a9d75197eb670fbd244b459e8af8c5e638005"
       ],
       "evidence": "../qa/L12.md",
       "blocker": null

--- a/docs/implementation/status.json
+++ b/docs/implementation/status.json
@@ -311,7 +311,8 @@
         "a516c46b678aea25894c41a4a3fb31870f613653",
         "0a9aeebaa2360f658cbd870e40187ab70c5dfac2",
         "f880d873d3cea7d23b78fff0c5eec1f8e5443ae3",
-        "e824244fd6034afd493fdfac2954cf49cdbd9441"
+        "e824244fd6034afd493fdfac2954cf49cdbd9441",
+        "3cf96d4343c8a570e3340834f03902f00d9c83b3"
       ],
       "evidence": "../qa/L12.md",
       "blocker": null

--- a/docs/qa/L12.md
+++ b/docs/qa/L12.md
@@ -145,7 +145,7 @@ No dependency, physical printing, template restyling, PDF/UA claim, deployment, 
 
 ## S02d — printable forms and annotations
 
-Checks were executed on the story working tree based on `3cf96d4343c8a570e3340834f03902f00d9c83b3`; the resulting implementation SHA is recorded by the following tracking commit. No remote CI or completed-lot claim is made.
+Implementation, tests and evidence commit: `4c4a9d75197eb670fbd244b459e8af8c5e638005`, based on `3cf96d4343c8a570e3340834f03902f00d9c83b3`. Checks were executed on the story working tree before that commit. No remote CI or completed-lot claim is made.
 
 Implemented after the maintainer requested continuation from S02c. The printable API decision was written in COMPONENT_CATALOG before implementation. Alert and Badge expose readable status labels with neutral theme roles. Form validates bounded, uniquely identified groups/fields and composes one/two/three-column printable rows, including blank values, visible required labels and multiline values. Signature offers single/dual areas and a single inline field with bounded writing space and optional name/role/date. Watermark uses the DocumentFrame body rectangle, bounded opacity/font size, conservative Latin-text envelopes and top/center/bottom placement; final subpage numbering controls first-page-only marks independently of repetition.
 

--- a/docs/qa/L12.md
+++ b/docs/qa/L12.md
@@ -6,7 +6,7 @@ Issue [#16](https://github.com/Osiris-Balonga/docn-ui/issues/16); Project item `
 
 ## Scope
 
-L12-S01 and S02a–S02c are implemented and locally verified. Eight guides cover installation, local assets, independent browser/Node usage, themes, formats, locale/data, updates and limitations. Shared frames, core content and pagination/table primitives are implemented below. The documentation index, sidebar, search and section anchors expose the same guide inventory. Template redesign remains paused. The remaining component stories are S02d–S02h; the lot is not yet verified or ready to merge.
+L12-S01 and S02a–S02d are implemented and locally verified. Eight guides cover installation, local assets, independent browser/Node usage, themes, formats, locale/data, updates and limitations. Shared frames, core content, pagination/tables and printable forms/annotations are implemented below. The documentation index, sidebar, search and section anchors expose the same guide inventory. Template redesign remains paused. The remaining component stories are S02e–S02h; the lot is not yet verified or ready to merge.
 
 The browser, Node and Vite build snippets come from `packages/documents/src/examples/consumer-usage.ts`, also consumed by the existing external installation scenario. Documentation and template source share token rendering, code scrolling and accessible copy controls. Shell commands deliberately avoid TypeScript tokenization. Installed source uses the configured registry origin, with an explicit distinction between the default registry preview on port 4173 and a documentation server on port 3000.
 
@@ -142,3 +142,35 @@ The first real PDF test exposed missing PageNumber text. Reserving width/minimum
 Heights remain an explicit author/premeasurement contract: callers must measure cells at the actual full body width and selected font, including padding/borders, and reserve enough header/footer space. Arbitrary nested cell JSX, automatic oversized-content splitting, clipped/shrunken rows and implicit font/layout measurement are not promised. Repetition belongs to DocumentFrame; separate frames define different repeated headings. The initial flow-page format remains portrait A4/Letter screen/trim geometry. These are source capabilities, not yet public gallery completeness.
 
 No dependency, physical printing, template restyling, PDF/UA claim, deployment, release or L12 merge. Responsive/keyboard checks were not repeated for this PDF-only change; S01 covers the unchanged site shell. Next story: **L12-S02d**, printable form and annotation components. L12 remains **in progress**.
+
+## S02d — printable forms and annotations
+
+Checks were executed on the story working tree based on `3cf96d4343c8a570e3340834f03902f00d9c83b3`; the resulting implementation SHA is recorded by the following tracking commit. No remote CI or completed-lot claim is made.
+
+Implemented after the maintainer requested continuation from S02c. The printable API decision was written in COMPONENT_CATALOG before implementation. Alert and Badge expose readable status labels with neutral theme roles. Form validates bounded, uniquely identified groups/fields and composes one/two/three-column printable rows, including blank values, visible required labels and multiline values. Signature offers single/dual areas and a single inline field with bounded writing space and optional name/role/date. Watermark uses the DocumentFrame body rectangle, bounded opacity/font size, conservative Latin-text envelopes and top/center/bottom placement; final subpage numbering controls first-page-only marks independently of repetition.
+
+No DOM controls, AcroForm widgets, cryptographic signatures, signing services or document-protection features are introduced. Six runtime modules join the existing aggregate registry; no dependency was added. Existing templates, base primitive output and the site shell are unchanged. Individual registry entries and public component detail pages remain S02g/S02h.
+
+### Executed checks
+
+| Check | Actual result | Evidence |
+| --- | --- | --- |
+| `pnpm test:unit content.test measurement registry` | Passed, 3 files / 15 cases | Existing suite extended with three focused cases for field/group limits and identity, signer layouts/dimensions and watermark geometry/controls. |
+| `pnpm test:unit content.test` after review | Passed, 1 file / 7 cases | Explicit null column counts are rejected instead of silently defaulting. |
+| `DOCN_WRITE_PDF_ARTIFACTS=1 pnpm test:pdf primitives` | Passed, 1 file / 3 cases, repeated after layout adjustment | Existing shared specimens retained; content example extended from one to two pages rather than creating a separate suite. Nine total pages across the three specimens. |
+| Actual PDF inspection, Poppler at 90 dpi | Passed, both content-specimen pages | All five categories, neutral styling, blank fields, multiline address, matching row rules, two signer areas, single/inline lines and restrained marks. Final second page re-rendered and inspected after alignment correction. |
+| `pnpm quality` | Passed | Formatting, lint and workspace/root types. Targeted formatting/lint rerun after the alignment and null-validation edits; build also checks final application types. |
+| `pnpm test:consumers` | Passed, 1 orchestral case, 112.57 seconds | Official shadcn installs in two temporary projects with retained configuration and actual browser/Node PDFs after the registry stops. Six added modules explain exact source counts of 59/60. |
+| `pnpm verify:registry` | Passed, 24 items / 5 assets | Current source closure regenerated and checked against the pinned official schema. |
+| `pnpm build` / `pnpm verify:docs` | Passed, 30 pages / 10 documentation pages / 254 links | Static routes compile against the current expanded aggregate source closure; all existing local anchors/links resolve. |
+| `git diff --check` | Passed | No whitespace errors. |
+
+### Evidence and limits
+
+The shared example `packages/documents/src/examples/primitive-content.tsx` now includes one-column reference fields, two-column contact fields with a wrapped address and blank telephone, three-column review fields with an incomplete final row, explicit required text, compact/regular badges, neutral and explicitly labeled notices, all three signature arrangements and repeated/one-time watermarks. The PDF test verifies every relevant label, two pages, physical text bounds, column alignment, matching dual-signer labels, no interactive field objects, no page-two annotations, DRAFT on both pages and SAMPLE only on page one. Existing links, local media, typography, pagination and flow-frame assertions still pass.
+
+Generated artifacts (not committed): `.artifacts/l12/pdf/primitive-content.pdf`, `.artifacts/l12/rendered/primitive-content-s02d-{1,2}.png` and the existing external-consumer logs. The first visual inspection caught unequal bottom rules when a neighboring field contained two lines; the value area now grows to the row height. The inline signature label was aligned with its writing line. PDF tests and visual inspection were repeated after these corrections. Consumer dependency/configuration evidence preceded these style-only and null-input edits; the current registry was regenerated and verified afterward, without adding a redundant external-install matrix. The small Vite consumer still reports its existing large PDF-engine chunk warning; this story does not claim a bundle-size optimization.
+
+Form rows, signature groups and fixed-page content require author qualification at the actual width/font; this story does not introduce an arbitrary text-measurement engine, clipping, font shrinking or automatic splitting of oversized unbreakable rows. Group titles stay with the first row. Watermark is currently a direct DocumentFrame child after body content, horizontal, 1–24 printable Latin characters, 12–48 pt and opacity 0.02–0.2. It does not support rotated marks, image marks, arbitrary Unicode shaping or fixed-format PageFrame placement. No claim of PDF/UA, secure signing, tax compliance, physical print contrast or printer calibration is made.
+
+PDF and React skill guidance led to extending the existing real-PDF specimen and inspecting its actual raster output; shadcn guidance preserved the official source installation/configuration boundary. Responsive/keyboard/reduced-motion checks were not repeated because no site UI or interactive behavior changed; S01 evidence remains applicable. No template redesign, dependency, deployment, release, L12 PR or merge. Next story: **L12-S02e**, vector graph components. L12 remains **in progress**.

--- a/docs/qa/L12.md
+++ b/docs/qa/L12.md
@@ -6,7 +6,7 @@ Issue [#16](https://github.com/Osiris-Balonga/docn-ui/issues/16); Project item `
 
 ## Scope
 
-L12-S01, S02a and S02b are implemented and locally verified. Eight guides cover installation, local assets, independent browser/Node usage, themes, formats, locale/data, updates and limitations. Shared frames and core content primitives are implemented below. The documentation index, sidebar, search and section anchors expose the same guide inventory. Template redesign remains paused. The remaining component stories are S02c–S02h; the lot is not yet verified or ready to merge.
+L12-S01 and S02a–S02c are implemented and locally verified. Eight guides cover installation, local assets, independent browser/Node usage, themes, formats, locale/data, updates and limitations. Shared frames, core content and pagination/table primitives are implemented below. The documentation index, sidebar, search and section anchors expose the same guide inventory. Template redesign remains paused. The remaining component stories are S02d–S02h; the lot is not yet verified or ready to merge.
 
 The browser, Node and Vite build snippets come from `packages/documents/src/examples/consumer-usage.ts`, also consumed by the existing external installation scenario. Documentation and template source share token rendering, code scrolling and accessible copy controls. Shell commands deliberately avoid TypeScript tokenization. Installed source uses the configured registry origin, with an explicit distinction between the default registry preview on port 4173 and a documentation server on port 3000.
 
@@ -105,4 +105,38 @@ Generated QA files (not committed): `.artifacts/l12/pdf/primitive-content.pdf`, 
 
 A first formatting command used an unquoted brace glob that PowerShell rejected before running; quoting the glob fixed the invocation. All executed behavior checks passed; no failing commit, weakened threshold or replacement visual reference was used. No dependencies, license changes, template redesign, physical printing, PDF/UA claim, deployment or public release. No new responsive/keyboard test for this PDF-only source change; the unchanged site shell retains S01 evidence.
 
-Next story: **L12-S02c**, reusable pagination and table components. L12 remains **in progress**, not `verified_local`, merged or released.
+S02b continued into S02c below. L12 remains **in progress**, not `verified_local`, merged or released.
+
+## S02c — reusable pagination and tables
+
+Implemented after the maintainer approved continuation from S02b. The pagination/table API was recorded in COMPONENT_CATALOG before implementation. KeepTogether and PageBreak use the existing flow frame; PageHeader/PageFooter compose either inline or inside its reserved repeated regions. PageNumber uses the engine's final-pagination callback and a bounded configurable format.
+
+Table/Row/Cell/Header and DataTable share the existing invoice FlowTable helpers. Their additions are optional helper props: inline header positioning, declared minimum height and header text styling. Existing invoice source and default helper calls remain unchanged. Public table columns use validated percentage widths and unique keys; typed data accessors produce bounded strings/finite numbers and unique row keys. Rows and non-breaking groups require explicit premeasured heights and reject declarations exceeding the body or excluding required cell padding. No second table layout engine or automatic JSX-height estimator was added.
+
+Five source modules join the existing aggregate registry. Individual installation entries and public component detail pages remain S02g/S02h.
+
+### Executed checks
+
+| Check | Actual result | Evidence |
+| --- | --- | --- |
+| `pnpm test:unit table.test measurement registry` | Passed, 3 files / 12 cases | Four new focused cases cover column structure/widths, typed rows/keys/value limits, impossible row heights and page-number formats. Existing geometry and registry coverage reused. |
+| `DOCN_WRITE_PDF_ARTIFACTS=1 pnpm test:pdf primitives invoice` | Passed, 2 files / 6 cases | Existing shared frame/content specimens, one new pagination specimen, nominal invoices and both existing long-invoice cases. No unrelated family suite or QR matrix rerun. |
+| Poppler before/after invoice comparison at 72 dpi | Identical, 4 PDFs / 7 pages | Three nominal invoices plus the real long invoice. Previously verified S02b PDF artifacts were copied before regeneration; all corresponding PNG SHA-256 hashes match. |
+| Multipage specimen visual inspection at 90 dpi | Passed, all 4 pages | Forty entries over two pages, a complete summary on page 3 and explicit appendix break on page 4. Repeated title/column headers, contact footer and final page numbering are visible with no content overlap/clipping. |
+| `pnpm quality` | Passed | Formatting, lint and workspace/root types. New imports remain module-specific and all PDF composition stays independent of site UI. |
+| `pnpm verify:registry` | Passed, 24 items / 5 assets | Updated aggregate closure verifies against the pinned schema; no new dependency. |
+| `pnpm test:consumers` | Passed, 1 orchestral case, 162.63 seconds | Official CLI installation in two temporary external projects with unchanged configuration; actual browser/Node renders after the registry stops. Counts are 53/54, explicitly accounting for five added modules. |
+| `pnpm build` / `pnpm verify:docs` | Passed, 30 pages / 10 docs pages / 254 links | Existing site and guides compile with the expanded source closure. |
+| `git diff --check` | Passed | No whitespace errors. |
+
+### Evidence, correction and limits
+
+The reusable example is `packages/documents/src/examples/primitive-pagination.tsx`. The existing primitive PDF suite independently verifies four physical pages; every entry 001–040 exactly once; the complete wrapped first description; the final amount and summary marker together on page 3, not on page 2; the manual Table composition and empty DataTable on page 4; repeated headers/contact details; and exact final numbering on every page. Text coordinates are checked against separate header/body/footer rectangles, not only file size or text presence.
+
+Generated artifacts (not committed): `.artifacts/l12/pdf/primitive-pagination.pdf`, `.artifacts/l12/rendered/primitive-pagination-{1,2,3,4}.png`, `baseline-s02c`, `invoice-before-s02c` and `invoice-after-s02c`. The existing consumer artifacts/log were regenerated by the successful scenario.
+
+The first real PDF test exposed missing PageNumber text. Reserving width/minimum height did not fix it. Temporary inspection through the engine's onRender layout data showed a final numeric lineHeight of 3241.35 for 7 pt text and an empty laid-out line list: renderer 4.9.0 repeatedly resolves numeric lineHeight during dynamic pagination. PageNumber now leaves line height to font metrics, following the working native invoice callback pattern; its footer gets a bounded column. The final PDF test verifies all four numbers without weakening its assertions. Temporary diagnostics and the ineffective minimum-height workaround were removed. Initial lint also requested an explicit Image alt prop despite the typed spread; the header now supplies it explicitly. No failing commit or upstream engine patch was created.
+
+Heights remain an explicit author/premeasurement contract: callers must measure cells at the actual full body width and selected font, including padding/borders, and reserve enough header/footer space. Arbitrary nested cell JSX, automatic oversized-content splitting, clipped/shrunken rows and implicit font/layout measurement are not promised. Repetition belongs to DocumentFrame; separate frames define different repeated headings. The initial flow-page format remains portrait A4/Letter screen/trim geometry. These are source capabilities, not yet public gallery completeness.
+
+No dependency, physical printing, template restyling, PDF/UA claim, deployment, release or L12 merge. Responsive/keyboard checks were not repeated for this PDF-only change; S01 covers the unchanged site shell. Next story: **L12-S02d**, printable form and annotation components. L12 remains **in progress**.

--- a/docs/qa/L12.md
+++ b/docs/qa/L12.md
@@ -109,6 +109,8 @@ S02b continued into S02c below. L12 remains **in progress**, not `verified_local
 
 ## S02c — reusable pagination and tables
 
+Implementation, tests and evidence commit: `e824244fd6034afd493fdfac2954cf49cdbd9441`. Checks below were executed on the story working tree before its commit; no remote CI or completed-lot claim is made.
+
 Implemented after the maintainer approved continuation from S02b. The pagination/table API was recorded in COMPONENT_CATALOG before implementation. KeepTogether and PageBreak use the existing flow frame; PageHeader/PageFooter compose either inline or inside its reserved repeated regions. PageNumber uses the engine's final-pagination callback and a bounded configurable format.
 
 Table/Row/Cell/Header and DataTable share the existing invoice FlowTable helpers. Their additions are optional helper props: inline header positioning, declared minimum height and header text styling. Existing invoice source and default helper calls remain unchanged. Public table columns use validated percentage widths and unique keys; typed data accessors produce bounded strings/finite numbers and unique row keys. Rows and non-breaking groups require explicit premeasured heights and reject declarations exceeding the body or excluding required cell padding. No second table layout engine or automatic JSX-height estimator was added.

--- a/docs/specs/COMPONENT_CATALOG.md
+++ b/docs/specs/COMPONENT_CATALOG.md
@@ -1,6 +1,6 @@
 # PDF component catalog — PDFx comparison and L12 contract
 
-Date: 2026-08-31. Status: **L12 in progress**, not a public component availability claim. S01 and the S02a shared-frame foundation are locally verified; the remaining component stories and gallery are planned. The maintainer requested component availability and documentation before further template redesign. L12 must cover the component categories below and add barcodes. Existing template compositions remain unchanged during this work, except for necessary, behavior-preserving imports.
+Date: 2026-08-31. Status: **L12 in progress**, not a public component availability claim. S01 and S02a–S02c are locally verified; the remaining component stories and gallery are planned. The maintainer requested component availability and documentation before further template redesign. L12 must cover the component categories below and add barcodes. Existing template compositions remain unchanged during this work, except for necessary, behavior-preserving imports.
 
 ## Evidence and scope
 
@@ -97,6 +97,20 @@ These are source-owned PDF APIs, not drop-in PDFx props. Existing calls and defa
 - `QRCode` keeps its existing vector renderer, payload limit, minimum module size and four-module quiet zone. This story does not add another encoder or alter scanner qualification.
 
 The combined typed example is compiled project source, not visitor-supplied JSX. It qualifies actual selectable text, external/internal link annotations, a local image, nested lists and QR composition in one PDF. Component-sized registry entries and public gallery routes remain S02g/S02h work.
+
+## S02c pagination and table API decision
+
+`KeepTogether` is a normal-flow, non-breaking group with a required `measuredHeight` in points. It reserves that minimum height and rejects a non-finite, non-positive or larger-than-body value with LAYOUT_OVERFLOW. Children are trusted, premeasured composition: their actual height must not exceed the supplied reservation. The component does not measure arbitrary JSX, clip it, shrink its font or split it silently. `PageBreak` requires following children and starts that content on a new flowing page; do not put it inside KeepTogether or use it as an empty trailing marker. Both require DocumentFrame's flow context.
+
+`PageHeader` and `PageFooter` are inline content compositions. Put them into DocumentFrame's existing `{ content, height, gap }` regions to repeat them with reserved space; use them in body flow for one-time content. Header accepts an optional locally resolved Image; footer accepts contact/other children and optional PageNumber props. Region heights remain explicitly declared and must cover their children. `PageNumber` uses the engine's final-pagination callback with a bounded format string containing `{page}` and optionally `{pages}` (default `Page {page} of {pages}`); numbering covers the whole Document, not a reset per frame.
+
+`Table`, `TableRow`, `TableCell` and `TableHeader` compose through the existing FlowTable helpers. Public columns have unique keys, readable labels, left/right alignment and numeric percentage widths totaling 100; one to twelve columns are allowed. TableRow requires a measured height and exactly one direct TableCell per column, in column order. Cells accept bounded strings or finite numbers, not arbitrary unmeasured nested JSX. Natural text wrapping remains enabled. The reservation includes vertical cell padding and borders; rows must be measured at the actual table width/font, and every non-breaking row must fit the complete flow body. Oversized declarations are rejected, never split or truncated.
+
+`TableHeader` accepts the same column constant and a measured height. Place it in a reserved PageHeader region for repetition, or in flow for a one-time heading. It is not an independently fixed overlay: the parent frame owns repetition and spacing, so table columns cannot silently overwrite a document title. Separate frames define distinct repeated table headings when a document contains different tables. Header labels must fit the declared height. The initial table surface spans the full flow-body width; do not nest it inside a narrower column without a separately measured frame.
+
+`DataTable<T>` maps typed data with `cell(row)`, `rowKey(row, index)` and `rowHeight(row, index)` callbacks to those same Table/Row/Cell components. It accepts at most 500 rows, 12 columns and 2,000 characters per cell, rejects duplicate/empty keys, invalid values and oversized row declarations, and supports an explicit empty-message prop. Callbacks are trusted compiled source, not user-entered code. Row heights are required rather than guessed from character count. This is deliberately not a universal automatic text-measurement engine; native wrapping and the documented premeasurement boundary remain visible.
+
+The shared multipage specimen will qualify repeated headers/footers, final numbering, first/last rows exactly once, wrapped cells, a summary that moves intact and an explicit break into a compositional table. Existing invoice helper calls and nominal layouts must remain unchanged.
 
 ## shadcn installation and theme continuity
 

--- a/docs/specs/COMPONENT_CATALOG.md
+++ b/docs/specs/COMPONENT_CATALOG.md
@@ -1,6 +1,6 @@
 # PDF component catalog — PDFx comparison and L12 contract
 
-Date: 2026-08-31. Status: **L12 in progress**, not a public component availability claim. S01 and S02a–S02c are locally verified; the remaining component stories and gallery are planned. The maintainer requested component availability and documentation before further template redesign. L12 must cover the component categories below and add barcodes. Existing template compositions remain unchanged during this work, except for necessary, behavior-preserving imports.
+Date: 2026-08-31. Status: **L12 in progress**, not a public component availability claim. S01 and S02a–S02d are locally verified; the remaining component stories and gallery are planned. The maintainer requested component availability and documentation before further template redesign. L12 must cover the component categories below and add barcodes. Existing template compositions remain unchanged during this work, except for necessary, behavior-preserving imports.
 
 ## Evidence and scope
 
@@ -111,6 +111,18 @@ The combined typed example is compiled project source, not visitor-supplied JSX.
 `DataTable<T>` maps typed data with `cell(row)`, `rowKey(row, index)` and `rowHeight(row, index)` callbacks to those same Table/Row/Cell components. It accepts at most 500 rows, 12 columns and 2,000 characters per cell, rejects duplicate/empty keys, invalid values and oversized row declarations, and supports an explicit empty-message prop. Callbacks are trusted compiled source, not user-entered code. Row heights are required rather than guessed from character count. This is deliberately not a universal automatic text-measurement engine; native wrapping and the documented premeasurement boundary remain visible.
 
 The shared multipage specimen will qualify repeated headers/footers, final numbering, first/last rows exactly once, wrapped cells, a summary that moves intact and an explicit break into a compositional table. Existing invoice helper calls and nominal layouts must remain unchanged.
+
+## S02d printable form and annotation API decision
+
+`Alert` accepts a required title, optional supporting text and a visible status label (`Note` by default). `Badge` accepts a required short label, compact/regular sizing and neutral/outline tone. Both use the PDF theme's monochrome roles, never an implicit status color or site icon. Text stays selectable and wraps naturally. These inline compositions work in either frame; callers remain responsible for fitting trusted content into fixed pages.
+
+`Form` accepts one to twelve titled groups, each with one to three equal-width columns and bounded fields (`id`, `label`, optional `value` and `required`). At most 60 fields are allowed; identifiers are unique across groups. Missing/empty values leave a writing line. Required fields print `(required)` beside the label. Rows are non-breaking, groups may continue between rows, and the group title stays with its first row. There are no HTML inputs, submission handlers, hidden data fields or interactive AcroForms. Values are bounded strings, not evaluated JSX. Text wraps without clipping; authors must qualify row heights at the actual width and theme before placing unusually long content or large fonts on a page.
+
+`Signature` accepts one or two signers with a required label and optional name, role and date. Stacked areas reserve a configurable 24–96 pt writing space (default 40 pt) above the signature line. Inline mode supports exactly one signer. Names are printed text, not reproduced handwriting; no cryptographic signature, identity verification or legal validity is implied. The signer group is non-breaking and must fit its containing frame.
+
+`Watermark` is a direct child of DocumentFrame, not a nested flow block. It uses the reserved body rectangle, never the header/footer. Its horizontal text is placed at the top, center (default) or bottom of that rectangle, with opacity 0.02–0.2 (default 0.08), font size 12–48 pt (default 32), and repeat enabled by default. With repeat disabled it appears only on the first page of that frame, regardless of preceding frames. A conservative width/height envelope rejects labels that cannot fit without shrinking or clipping. The first surface accepts 1–24 printable Latin characters; rotated marks, images, arbitrary Unicode shaping and fixed-format PageFrame placement are not yet qualified. Place it after body content for a visible overlay. Watermarks are annotations of intent, not document protection; printed contrast still requires review.
+
+The existing shared content specimen will gain printable forms/annotations and a second page to verify repeated versus first-page-only watermarks. No new dependency, template restyling or site shell change is required. The aggregate registry remains compatible; individually installable items and public examples arrive in S02g/S02h.
 
 ## shadcn installation and theme continuity
 

--- a/packages/documents/src/examples/primitive-content.tsx
+++ b/packages/documents/src/examples/primitive-content.tsx
@@ -2,6 +2,11 @@ import { Document, View } from "@react-pdf/renderer";
 import { resolveFormat } from "../core/formats";
 import { Card, Section } from "../primitives/containers";
 import { DocumentFrame } from "../primitives/document-frame";
+import { Alert, Badge } from "../primitives/annotations";
+import { Form } from "../primitives/form";
+import { PageBreak } from "../primitives/pagination";
+import { Signature } from "../primitives/signature";
+import { Watermark } from "../primitives/watermark";
 import { Image } from "../primitives/image";
 import { Divider, Row, Stack } from "../primitives/layout";
 import { Link } from "../primitives/link";
@@ -130,6 +135,113 @@ export function createPrimitiveContentPlan(
               </Text>
             </Section>
           </Stack>
+          <PageBreak>
+            <Stack gap="lg">
+              <Stack gap="sm">
+                <Text size="caption" tone="muted">
+                  DOCN-UI / PRINTABLE ANNOTATIONS
+                </Text>
+                <Heading level={1}>Review and sign-off</Heading>
+                <Text>
+                  Static fields and signature lines. Edit the source to add your
+                  own theme.
+                </Text>
+              </Stack>
+              <Row gap="md" align="center">
+                <Badge label="Draft" />
+                <Badge label="Review pending" size="regular" tone="outline" />
+              </Row>
+              <Alert
+                title="Complete before printing"
+                description="Review the populated values and leave the blank fields for handwritten information."
+              />
+              <Form
+                groups={[
+                  {
+                    id: "reference",
+                    title: "Document reference",
+                    fields: [
+                      {
+                        id: "purpose",
+                        label: "Purpose",
+                        value: "Proof approval for the community publication.",
+                      },
+                    ],
+                  },
+                  {
+                    id: "contact",
+                    title: "Contact information",
+                    columns: 2,
+                    fields: [
+                      {
+                        id: "name",
+                        label: "Full name",
+                        value: "Élodie Mbemba",
+                        required: true,
+                      },
+                      {
+                        id: "email",
+                        label: "Email",
+                        value: "elodie@example.com",
+                      },
+                      {
+                        id: "address",
+                        label: "Postal address",
+                        value: "14 avenue des Arts\nBrazzaville",
+                      },
+                      { id: "phone", label: "Telephone" },
+                    ],
+                  },
+                  {
+                    id: "review",
+                    title: "Review details",
+                    columns: 3,
+                    fields: [
+                      {
+                        id: "reference-id",
+                        label: "Reference",
+                        value: "DOC-026",
+                      },
+                      { id: "copies", label: "Copies", value: "25" },
+                      { id: "date", label: "Review date", value: "" },
+                      { id: "notes", label: "Review notes" },
+                    ],
+                  },
+                ]}
+              />
+              <Signature
+                signers={[
+                  {
+                    label: "Prepared by",
+                    name: "Élodie Mbemba",
+                    role: "Editor",
+                    date: "15 January 2026",
+                  },
+                  {
+                    label: "Approved by",
+                    name: "Morgan Lee",
+                    role: "Reviewer",
+                  },
+                ]}
+              />
+              <Signature
+                space={24}
+                signers={[{ label: "Witness signature" }]}
+              />
+              <Signature
+                layout="inline"
+                space={24}
+                signers={[{ label: "Collected by" }]}
+              />
+              <Alert
+                status="Important"
+                title="Static print elements only"
+                description="No interactive form fields, digital signatures or document protection are provided."
+              />
+            </Stack>
+          </PageBreak>
+          <Watermark text="DRAFT" placement="bottom" />
+          <Watermark text="SAMPLE" fontSize={20} repeat={false} />
         </DocumentFrame>
       </Document>
     ),

--- a/packages/documents/src/examples/primitive-pagination.tsx
+++ b/packages/documents/src/examples/primitive-pagination.tsx
@@ -1,0 +1,172 @@
+import { Document, View } from "@react-pdf/renderer";
+import { resolveFormat } from "../core/formats";
+import {
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+} from "../primitives/composable-table";
+import { DataTable, type DataTableColumn } from "../primitives/data-table";
+import { DocumentFrame } from "../primitives/document-frame";
+import { Divider, Stack } from "../primitives/layout";
+import { PageFooter, PageHeader } from "../primitives/page-regions";
+import { KeepTogether, PageBreak } from "../primitives/pagination";
+import { Heading, KeyValue, Text } from "../primitives/typography";
+import type { FixedDocumentRenderPlan } from "../render/runtime";
+import { getPdfTheme } from "../themes/themes";
+
+export interface PaginationRow {
+  id: string;
+  description: string;
+  quantity: number;
+  amount: string;
+  height: number;
+}
+export const paginationColumns = [
+  {
+    key: "description",
+    label: "Description",
+    width: 60,
+    cell: (row) => row.description,
+  },
+  {
+    key: "quantity",
+    label: "Qty",
+    width: 12,
+    align: "right",
+    cell: (row) => row.quantity,
+  },
+  {
+    key: "amount",
+    label: "Amount",
+    width: 28,
+    align: "right",
+    cell: (row) => row.amount,
+  },
+] as const satisfies readonly DataTableColumn<PaginationRow>[];
+
+export const paginationRows: readonly PaginationRow[] = Array.from(
+  { length: 40 },
+  (_, index) => ({
+    id: `entry-${index + 1}`,
+    description: `Entry ${String(index + 1).padStart(3, "0")}${index === 0 ? " - A longer description that wraps while keeping its quantity and amount on the same physical page." : " - Document preparation and review"}`,
+    quantity: 1,
+    amount: "25.00",
+    // Measured for this bounded fixture at 60% of the A4 body width with 9 pt Noto Sans.
+    height: index === 0 ? 44 : 28,
+  }),
+);
+
+export function createPrimitivePaginationPlan(): FixedDocumentRenderPlan {
+  const format = resolveFormat("a4");
+  if (format.kind !== "fixed") throw new Error("Expected A4.");
+  const fixedDate = new Date("2026-01-15T12:00:00.000Z");
+  return {
+    format,
+    printProfile: { kind: "screen" },
+    document: (
+      <Document
+        title="Reusable pagination and tables"
+        creationDate={fixedDate}
+        modificationDate={fixedDate}
+        language="en-GB"
+      >
+        <DocumentFrame
+          format={format}
+          theme={getPdfTheme("neutral")}
+          margin={36}
+          header={{
+            height: 64,
+            gap: 12,
+            content: (
+              <PageHeader>
+                <Stack gap="xs">
+                  <Heading>Production ledger</Heading>
+                  <Text size="caption" tone="muted">
+                    DOCN-UI / REUSABLE PAGINATION
+                  </Text>
+                  <TableHeader
+                    columns={paginationColumns}
+                    measuredHeight={24}
+                  />
+                </Stack>
+              </PageHeader>
+            ),
+          }}
+          footer={{
+            height: 20,
+            gap: 12,
+            content: (
+              <PageFooter pageNumber={{ format: "Ledger {page} / {pages}" }}>
+                <Text size="caption" tone="muted">
+                  hello@example.com
+                </Text>
+              </PageFooter>
+            ),
+          }}
+        >
+          <DataTable
+            columns={paginationColumns}
+            data={paginationRows}
+            rowKey={(row) => row.id}
+            rowHeight={(row) => row.height}
+          />
+          <KeepTogether measuredHeight={220}>
+            <View style={{ paddingTop: 16 }}>
+              <Stack gap="md">
+                <Heading>Final summary</Heading>
+                <KeyValue
+                  orientation="horizontal"
+                  label="Entries reviewed"
+                  value="40"
+                />
+                <KeyValue
+                  orientation="horizontal"
+                  label="Total"
+                  value="1,000.00"
+                />
+                <Divider />
+                <Text>
+                  The summary and its reserved sign-off space stay together.
+                </Text>
+                <View
+                  style={{
+                    height: 72,
+                    borderBottomWidth: 0.5,
+                    borderBottomColor: "#cccccc",
+                  }}
+                />
+                <Text size="caption">SUMMARY-END</Text>
+              </Stack>
+            </View>
+          </KeepTogether>
+          <PageBreak>
+            <Stack gap="md">
+              <Heading>Verification appendix</Heading>
+              <Text>
+                This explicit page break starts a separately composed table.
+              </Text>
+              <Table columns={paginationColumns}>
+                <TableRow measuredHeight={28}>
+                  <TableCell column="description">
+                    Manual verification entry
+                  </TableCell>
+                  <TableCell column="quantity">1</TableCell>
+                  <TableCell column="amount">25.00</TableCell>
+                </TableRow>
+              </Table>
+              <DataTable
+                columns={paginationColumns}
+                data={[]}
+                rowKey={(row) => row.id}
+                rowHeight={(row) => row.height}
+                emptyMessage="No outstanding entries."
+              />
+              <Text size="caption">APPENDIX-END</Text>
+            </Stack>
+          </PageBreak>
+        </DocumentFrame>
+      </Document>
+    ),
+  };
+}

--- a/packages/documents/src/primitives/annotations.tsx
+++ b/packages/documents/src/primitives/annotations.tsx
@@ -1,0 +1,75 @@
+import { View } from "@react-pdf/renderer";
+import { assertPrintText, invalidPrintData } from "./printable-data";
+import { usePdfTheme } from "./theme-context";
+import { Text } from "./typography";
+
+export interface AlertProps {
+  title: string;
+  description?: string;
+  status?: string;
+}
+
+export function Alert({ title, description, status = "Note" }: AlertProps) {
+  const theme = usePdfTheme();
+  assertPrintText(title, "title");
+  assertPrintText(status, "status", 32);
+  if (description !== undefined)
+    assertPrintText(description, "description", 2000);
+  return (
+    <View
+      style={{
+        borderLeftWidth: 2,
+        borderLeftColor: theme.colors.text,
+        paddingLeft: theme.spacing.md,
+        gap: theme.spacing.sm,
+      }}
+    >
+      <Text size="caption" weight="strong">
+        {status}
+      </Text>
+      <Text size="label" weight="strong">
+        {title}
+      </Text>
+      {description === undefined ? null : <Text>{description}</Text>}
+    </View>
+  );
+}
+
+export interface BadgeProps {
+  label: string;
+  size?: "compact" | "regular";
+  tone?: "neutral" | "outline";
+}
+
+export function Badge({
+  label,
+  size = "compact",
+  tone = "neutral",
+}: BadgeProps) {
+  const theme = usePdfTheme();
+  assertPrintText(label, "label", 48);
+  if (
+    !["compact", "regular"].includes(size) ||
+    !["neutral", "outline"].includes(tone)
+  )
+    invalidPrintData("Unknown badge size or tone.", "badge");
+  return (
+    <View
+      wrap={false}
+      style={{
+        alignSelf: "flex-start",
+        borderWidth: 0.5,
+        borderColor: theme.colors.border,
+        borderRadius: 3,
+        backgroundColor:
+          tone === "neutral" ? theme.colors.canvas : theme.colors.surface,
+        paddingHorizontal: theme.spacing.sm,
+        paddingVertical: theme.spacing.xs,
+      }}
+    >
+      <Text size={size === "compact" ? "caption" : "body"} weight="strong">
+        {label}
+      </Text>
+    </View>
+  );
+}

--- a/packages/documents/src/primitives/composable-table.tsx
+++ b/packages/documents/src/primitives/composable-table.tsx
@@ -1,0 +1,147 @@
+import { View } from "@react-pdf/renderer";
+import {
+  Children,
+  createContext,
+  isValidElement,
+  useContext,
+  type ReactNode,
+} from "react";
+import { DocumentValidationError } from "../core/errors";
+import { useFlowFrame } from "./flow-context";
+import { usePdfTheme } from "./theme-context";
+import { FlowTableCell, FlowTableHeader, FlowTableRow } from "./table";
+import {
+  assertTableColumns,
+  assertTableHeight,
+  assertTableValue,
+  type TableColumn,
+  type TableValue,
+} from "./table-data";
+
+const TableContext = createContext<readonly TableColumn[] | null>(null);
+function useTableColumns() {
+  const columns = useContext(TableContext);
+  if (!columns) throw new Error("TableRow and TableCell require Table.");
+  return columns;
+}
+
+export interface TableProps {
+  columns: readonly TableColumn[];
+  children: ReactNode;
+}
+export function Table({ columns, children }: TableProps) {
+  const frame = useFlowFrame();
+  assertTableColumns(columns);
+  return (
+    <TableContext.Provider value={columns}>
+      <View style={{ width: frame.body.width }}>{children}</View>
+    </TableContext.Provider>
+  );
+}
+
+export interface TableCellProps {
+  column: string;
+  children: TableValue;
+}
+export function TableCell({ column, children }: TableCellProps) {
+  const columns = useTableColumns();
+  const theme = usePdfTheme();
+  const definition = columns.find((item) => item.key === column);
+  if (!definition)
+    throw new DocumentValidationError([
+      {
+        code: "INVALID_DATA",
+        message: "Unknown table column.",
+        path: ["table", "cells", column],
+      },
+    ]);
+  assertTableValue(children, ["cells", column]);
+  return (
+    <FlowTableCell
+      width={`${definition.width}%`}
+      align={definition.align ?? "left"}
+      style={{
+        color: theme.colors.text,
+        fontFamily: theme.fonts.body,
+        fontSize: theme.typeScale.body,
+      }}
+    >
+      {children}
+    </FlowTableCell>
+  );
+}
+
+export interface TableRowProps {
+  children: ReactNode;
+  measuredHeight: number;
+}
+export function TableRow({ children, measuredHeight }: TableRowProps) {
+  const columns = useTableColumns();
+  const frame = useFlowFrame();
+  const theme = usePdfTheme();
+  assertTableHeight(
+    measuredHeight,
+    frame,
+    Math.max(28, theme.typeScale.body * 1.35 + 14.5),
+    ["row", "height"],
+  );
+  const cells = Children.toArray(children);
+  if (
+    cells.length !== columns.length ||
+    cells.some(
+      (cell, index) =>
+        !isValidElement<TableCellProps>(cell) ||
+        cell.type !== TableCell ||
+        cell.props.column !== columns[index]?.key,
+    )
+  )
+    throw new DocumentValidationError([
+      {
+        code: "INVALID_DATA",
+        message:
+          "Provide exactly one direct TableCell per column, in column order.",
+        path: ["table", "row", "cells"],
+      },
+    ]);
+  return (
+    <FlowTableRow borderColor={theme.colors.border} minHeight={measuredHeight}>
+      {children}
+    </FlowTableRow>
+  );
+}
+
+export interface TableHeaderProps {
+  columns: readonly TableColumn[];
+  measuredHeight: number;
+}
+export function TableHeader({ columns, measuredHeight }: TableHeaderProps) {
+  const theme = usePdfTheme();
+  const frame = useFlowFrame();
+  assertTableColumns(columns);
+  assertTableHeight(
+    measuredHeight,
+    frame,
+    theme.typeScale.caption * 1.35 + 12.75,
+    ["header", "height"],
+  );
+  return (
+    <FlowTableHeader
+      inline
+      top={0}
+      minHeight={measuredHeight}
+      columns={columns.map((column) => ({
+        ...column,
+        width: `${column.width}%`,
+      }))}
+      color={theme.colors.text}
+      backgroundColor={theme.colors.surface}
+      borderColor={theme.colors.border}
+      textStyle={{
+        fontFamily: theme.fonts.body,
+        fontSize: theme.typeScale.caption,
+        lineHeight: 1.35,
+      }}
+    />
+  );
+}
+export type { TableColumn, TableValue } from "./table-data";

--- a/packages/documents/src/primitives/content.test.ts
+++ b/packages/documents/src/primitives/content.test.ts
@@ -4,8 +4,128 @@ import { assertDestinationId, validateLink } from "./link-validation";
 import { assertListItems, type ListItem } from "./list-data";
 import { FieldPair, KeyValue } from "./typography";
 import { Divider, Separator } from "./layout";
+import {
+  assertFormGroups,
+  assertSignature,
+  type FormGroup,
+  type SignatureProps,
+} from "./printable-data";
+import { getWatermarkLayout, type WatermarkProps } from "./watermark-layout";
 
 describe("content primitive contracts", () => {
+  it("validates grouped print fields without losing blank values or repeated IDs", () => {
+    const group: FormGroup = {
+      id: "contact",
+      title: "Contact",
+      fields: [{ id: "name", label: "Name", value: "", required: true }],
+    };
+    for (const columns of [1, 2, 3] as const)
+      expect(() => assertFormGroups([{ ...group, columns }])).not.toThrow();
+    for (const groups of [
+      [],
+      null,
+      [null],
+      [group, group],
+      [{ ...group, columns: 4 }],
+      [{ ...group, columns: null }],
+      [{ ...group, fields: [] }],
+      [{ ...group, fields: [null] }],
+      [group, { ...group, id: "other" }],
+      [{ ...group, fields: [{ id: "x", label: " " }] }],
+      [{ ...group, fields: [{ id: "x", label: "Name", required: "yes" }] }],
+      [
+        {
+          ...group,
+          fields: [{ id: "x", label: "Name", value: "a".repeat(2001) }],
+        },
+      ],
+      Array.from({ length: 13 }, (_, index) => ({
+        ...group,
+        id: String(index),
+      })),
+      [
+        {
+          ...group,
+          fields: Array.from({ length: 61 }, (_, index) => ({
+            id: String(index),
+            label: "Name",
+          })),
+        },
+      ],
+    ])
+      expect(() => assertFormGroups(groups as readonly FormGroup[])).toThrow();
+  });
+
+  it("bounds signer groups, inline layout and writing space", () => {
+    const signers = [
+      {
+        label: "Prepared by",
+        name: "Élodie Mbemba",
+        role: "Editor",
+        date: "15 January 2026",
+      },
+    ];
+    expect(() => assertSignature({ signers })).not.toThrow();
+    expect(() =>
+      assertSignature({
+        signers: [...signers, { label: "Approved by" }],
+        space: 96,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertSignature({ signers, layout: "inline", space: 24 }),
+    ).not.toThrow();
+    for (const input of [
+      { signers: [] },
+      { signers: null },
+      { signers: [null] },
+      { signers: Array(3).fill(signers[0]) },
+      { signers: [...signers, ...signers], layout: "inline" },
+      { signers, layout: "unknown" },
+      { signers: [{ label: " " }] },
+      { signers: [{ label: "Signed by", name: 1 }] },
+      ...[0, 23, 97, NaN, Infinity].map((space) => ({ signers, space })),
+    ])
+      expect(() => assertSignature(input as SignatureProps)).toThrow();
+  });
+
+  it("contains watermark envelopes and rejects unreadable or unsupported controls", () => {
+    const body = { x: 36, y: 100, width: 523, height: 600 };
+    for (const [placement, y] of [
+      ["top", 100],
+      ["center", 368],
+      ["bottom", 636],
+    ] as const)
+      expect(getWatermarkLayout({ text: "DRAFT", placement }, body)).toEqual({
+        ...body,
+        y,
+        height: 64,
+      });
+    expect(() =>
+      getWatermarkLayout(
+        { text: "ÉPREUVE", fontSize: 24, repeat: false },
+        body,
+      ),
+    ).not.toThrow();
+    for (const input of [
+      { text: "" },
+      { text: "A".repeat(25) },
+      { text: "two\nlines" },
+      { text: "草稿" },
+      { text: "DRAFT", placement: "outside" },
+      { text: "DRAFT", repeat: "yes" },
+      ...[0, 0.21, NaN].map((opacity) => ({ text: "DRAFT", opacity })),
+      ...[11, 49, Infinity].map((fontSize) => ({ text: "DRAFT", fontSize })),
+    ])
+      expect(() => getWatermarkLayout(input as WatermarkProps, body)).toThrow();
+    expect(() =>
+      getWatermarkLayout({ text: "DRAFT" }, { ...body, width: 100 }),
+    ).toThrow(/envelope/);
+    expect(() =>
+      getWatermarkLayout({ text: "DRAFT" }, { ...body, height: 50 }),
+    ).toThrow(/envelope/);
+  });
+
   it("keeps aliases on one implementation", () => {
     expect(KeyValue).toBe(FieldPair);
     expect(Divider).toBe(Separator);

--- a/packages/documents/src/primitives/data-table.tsx
+++ b/packages/documents/src/primitives/data-table.tsx
@@ -1,0 +1,50 @@
+import { Table, TableCell, TableRow } from "./composable-table";
+import { useFlowFrame } from "./flow-context";
+import { usePdfTheme } from "./theme-context";
+import { prepareTableRows, type DataTableColumn } from "./table-data";
+import { Text } from "./typography";
+
+export interface DataTableProps<T> {
+  columns: readonly DataTableColumn<T>[];
+  data: readonly T[];
+  rowKey(row: T, index: number): string;
+  rowHeight(row: T, index: number): number;
+  emptyMessage?: string;
+}
+
+export function DataTable<T>({
+  columns,
+  data,
+  rowKey,
+  rowHeight,
+  emptyMessage = "No rows to display.",
+}: DataTableProps<T>) {
+  const frame = useFlowFrame();
+  const theme = usePdfTheme();
+  const rows = prepareTableRows(
+    columns,
+    data,
+    rowKey,
+    rowHeight,
+    frame,
+    Math.max(28, theme.typeScale.body * 1.35 + 14.5),
+  );
+  return (
+    <Table columns={columns}>
+      {rows.length ? (
+        rows.map((row) => (
+          <TableRow key={row.key} measuredHeight={row.height}>
+            {columns.map((column, index) => (
+              <TableCell key={column.key} column={column.key}>
+                {row.cells[index]!}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))
+      ) : (
+        <Text tone="muted">{emptyMessage}</Text>
+      )}
+    </Table>
+  );
+}
+export type { DataTableColumn } from "./table-data";

--- a/packages/documents/src/primitives/form.tsx
+++ b/packages/documents/src/primitives/form.tsx
@@ -1,0 +1,84 @@
+import { View } from "@react-pdf/renderer";
+import {
+  assertFormGroups,
+  type FormField,
+  type FormGroup,
+} from "./printable-data";
+import { usePdfTheme } from "./theme-context";
+import { Heading, Text } from "./typography";
+
+export type { FormField, FormGroup } from "./printable-data";
+export interface FormProps {
+  groups: readonly FormGroup[];
+}
+
+function FieldRow({
+  fields,
+  columns,
+}: {
+  fields: readonly FormField[];
+  columns: number;
+}) {
+  const theme = usePdfTheme();
+  return (
+    <View wrap={false} style={{ flexDirection: "row", gap: theme.spacing.lg }}>
+      {Array.from({ length: columns }, (_, index) => {
+        const field = fields[index];
+        return (
+          <View
+            key={field?.id ?? `blank-${index}`}
+            style={{ flex: 1, minWidth: 0 }}
+          >
+            {field ? (
+              <>
+                <Text size="caption" weight="strong">
+                  {field.label}
+                  {field.required ? " (required)" : ""}
+                </Text>
+                <View
+                  style={{
+                    flexGrow: 1,
+                    minHeight: theme.typeScale.body * 2 + theme.spacing.sm,
+                    paddingVertical: theme.spacing.sm,
+                    borderBottomColor: theme.colors.border,
+                    borderBottomWidth: 0.5,
+                  }}
+                >
+                  {field.value ? <Text>{field.value}</Text> : null}
+                </View>
+              </>
+            ) : null}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+export function Form({ groups }: FormProps) {
+  const theme = usePdfTheme();
+  assertFormGroups(groups);
+  return (
+    <View style={{ gap: theme.spacing.lg }}>
+      {groups.map((group) => {
+        const columns = group.columns ?? 1;
+        const rows = Array.from(
+          { length: Math.ceil(group.fields.length / columns) },
+          (_, index) =>
+            group.fields.slice(index * columns, (index + 1) * columns),
+        );
+        return (
+          <View key={group.id} style={{ gap: theme.spacing.md }}>
+            <View wrap={false} style={{ gap: theme.spacing.md }}>
+              <Heading level={3}>{group.title}</Heading>
+              <FieldRow fields={rows[0]!} columns={columns} />
+            </View>
+            {rows.slice(1).map((fields) => (
+              <FieldRow key={fields[0]!.id} fields={fields} columns={columns} />
+            ))}
+          </View>
+        );
+      })}
+    </View>
+  );
+}

--- a/packages/documents/src/primitives/index.tsx
+++ b/packages/documents/src/primitives/index.tsx
@@ -37,6 +37,36 @@ export { Image, type ImageProps } from "./image";
 export { Link, type LinkProps } from "./link";
 export { Section, Card, type SectionProps, type CardProps } from "./containers";
 export { List, type ListProps, type ListItem, type ListMarker } from "./list";
+export {
+  KeepTogether,
+  PageBreak,
+  PageNumber,
+  type KeepTogetherProps,
+  type PageNumberProps,
+} from "./pagination";
+export {
+  PageHeader,
+  PageFooter,
+  type PageHeaderProps,
+  type PageFooterProps,
+} from "./page-regions";
+export {
+  Table,
+  TableRow,
+  TableCell,
+  TableHeader,
+  type TableProps,
+  type TableRowProps,
+  type TableCellProps,
+  type TableHeaderProps,
+  type TableColumn,
+  type TableValue,
+} from "./composable-table";
+export {
+  DataTable,
+  type DataTableProps,
+  type DataTableColumn,
+} from "./data-table";
 export { QRCode, type QRCodeProps } from "./qr-code-view";
 export {
   createFlowFrame,

--- a/packages/documents/src/primitives/index.tsx
+++ b/packages/documents/src/primitives/index.tsx
@@ -68,6 +68,10 @@ export {
   type DataTableColumn,
 } from "./data-table";
 export { QRCode, type QRCodeProps } from "./qr-code-view";
+export { Alert, Badge, type AlertProps, type BadgeProps } from "./annotations";
+export { Form, type FormProps, type FormField, type FormGroup } from "./form";
+export { Signature, type SignatureProps, type Signer } from "./signature";
+export { Watermark, type WatermarkProps } from "./watermark";
 export {
   createFlowFrame,
   assertFlowBlockFits,

--- a/packages/documents/src/primitives/page-regions.tsx
+++ b/packages/documents/src/primitives/page-regions.tsx
@@ -1,0 +1,39 @@
+import { View } from "@react-pdf/renderer";
+import type { ReactNode } from "react";
+import { Image, type ImageProps } from "./image";
+import { Row } from "./layout";
+import { PageNumber, type PageNumberProps } from "./pagination";
+
+export interface PageHeaderProps {
+  children: ReactNode;
+  logo?: Pick<ImageProps, "alt" | "resolvedSource" | "width" | "height">;
+}
+
+// DocumentFrame owns repetition and reserves space; these can also be used inline.
+export function PageHeader({ children, logo }: PageHeaderProps) {
+  if (!logo) return <View>{children}</View>;
+  return (
+    <Row gap="md" align="center">
+      <Image {...logo} alt={logo.alt} />
+      <View style={{ flex: 1 }}>{children}</View>
+    </Row>
+  );
+}
+
+export interface PageFooterProps {
+  children?: ReactNode;
+  pageNumber?: false | PageNumberProps;
+}
+
+export function PageFooter({ children, pageNumber = {} }: PageFooterProps) {
+  return (
+    <Row gap="md" align="center" justify="between">
+      <View style={{ flex: 1 }}>{children}</View>
+      {pageNumber === false ? null : (
+        <View style={{ flex: 1 }}>
+          <PageNumber {...pageNumber} />
+        </View>
+      )}
+    </Row>
+  );
+}

--- a/packages/documents/src/primitives/pagination.tsx
+++ b/packages/documents/src/primitives/pagination.tsx
@@ -1,0 +1,87 @@
+import { Text as ReactPdfText, View } from "@react-pdf/renderer";
+import type { ReactNode } from "react";
+import { DocumentValidationError } from "../core/errors";
+import { assertFlowBlockFits } from "./flow-layout";
+import { useFlowFrame } from "./flow-context";
+import { usePdfTheme } from "./theme-context";
+import type { TextAlign } from "./typography";
+
+export interface KeepTogetherProps {
+  children: ReactNode;
+  measuredHeight: number;
+}
+
+export function KeepTogether({ children, measuredHeight }: KeepTogetherProps) {
+  assertFlowBlockFits(measuredHeight, useFlowFrame());
+  return (
+    <View wrap={false} style={{ minHeight: measuredHeight }}>
+      {children}
+    </View>
+  );
+}
+
+export function PageBreak({ children }: { children: ReactNode }) {
+  useFlowFrame();
+  if (
+    children === undefined ||
+    children === null ||
+    typeof children === "boolean"
+  ) {
+    throw new DocumentValidationError([
+      {
+        code: "INVALID_DATA",
+        message:
+          "PageBreak requires following content, not an empty trailing marker.",
+        path: ["pageBreak"],
+      },
+    ]);
+  }
+  return <View break>{children}</View>;
+}
+
+export interface PageNumberProps {
+  format?: string;
+  align?: TextAlign;
+}
+
+export function assertPageNumberFormat(format: string): void {
+  if (
+    typeof format !== "string" ||
+    format.length > 120 ||
+    !format.includes("{page}") ||
+    /[{}]/.test(format.replaceAll("{page}", "").replaceAll("{pages}", ""))
+  ) {
+    throw new DocumentValidationError([
+      {
+        code: "INVALID_DATA",
+        message:
+          "Use a page-number format of at most 120 characters with {page} and optional {pages} placeholders.",
+        path: ["pageNumber", "format"],
+      },
+    ]);
+  }
+}
+
+export function PageNumber({
+  format = "Page {page} of {pages}",
+  align = "right",
+}: PageNumberProps) {
+  const theme = usePdfTheme();
+  assertPageNumberFormat(format);
+  return (
+    <ReactPdfText
+      style={{
+        color: theme.colors.mutedText,
+        fontFamily: theme.fonts.body,
+        fontSize: theme.typeScale.caption,
+        // Numeric lineHeight is multiplied again on each dynamic relayout in renderer 4.9.0.
+        textAlign: align,
+      }}
+      render={({ pageNumber, totalPages }) =>
+        format
+          .replaceAll("{page}", String(pageNumber))
+          .replaceAll("{pages}", String(totalPages ?? pageNumber))
+      }
+    />
+  );
+}

--- a/packages/documents/src/primitives/primitives.pdf.test.tsx
+++ b/packages/documents/src/primitives/primitives.pdf.test.tsx
@@ -5,9 +5,82 @@ import { getDocument, OPS } from "pdfjs-dist/legacy/build/pdf.mjs";
 import { describe, expect, it } from "vitest";
 import { createPrimitiveFramesPlan } from "../examples/primitive-frames";
 import { createPrimitiveContentPlan } from "../examples/primitive-content";
+import { createPrimitivePaginationPlan } from "../examples/primitive-pagination";
 import { renderDocumentInNode } from "../render/node";
 
 describe("shared PDF primitive frames", () => {
+  it("keeps table rows, repeated regions, summaries and explicit breaks in their flow bounds", async () => {
+    const bytes = await renderDocumentInNode(createPrimitivePaginationPlan());
+    if (process.env.DOCN_WRITE_PDF_ARTIFACTS === "1") {
+      const directory = fileURLToPath(
+        new URL("../../../../.artifacts/l12/pdf/", import.meta.url),
+      );
+      await mkdir(directory, { recursive: true });
+      await writeFile(`${directory}primitive-pagination.pdf`, bytes);
+    }
+    const task = getDocument({ data: bytes.slice(), useSystemFonts: false });
+    try {
+      const document = await task.promise;
+      expect(document.numPages).toBe(4);
+      const pages: string[] = [];
+      for (let index = 1; index <= document.numPages; index++) {
+        const page = await document.getPage(index);
+        const content = await page.getTextContent();
+        const items = content.items.filter((item) => "str" in item);
+        const text = items.map((item) => item.str).join(" ");
+        pages.push(text);
+        expect(text).toContain("Production ledger");
+        expect(text).toContain("DESCRIPTION");
+        expect(text).toContain(`Ledger ${index} / 4`);
+        expect(text).toContain("hello@example.com");
+        for (const item of items.filter((item) => item.str.trim())) {
+          expect(item.transform[4]).toBeGreaterThanOrEqual(35.9);
+          expect(item.transform[4]! + item.width).toBeLessThanOrEqual(559.38);
+          const top = page.view[3]! - item.transform[5]! - item.height;
+          const isHeader = [
+            "Production ledger",
+            "DOCN-UI / REUSABLE PAGINATION",
+            "DESCRIPTION",
+            "QTY",
+            "AMOUNT",
+          ].includes(item.str);
+          const isFooter =
+            item.str === "hello@example.com" || item.str.startsWith("Ledger ");
+          if (isHeader) {
+            expect(top).toBeGreaterThanOrEqual(35.9);
+            expect(top + item.height).toBeLessThanOrEqual(100.1);
+          } else if (isFooter) {
+            expect(top).toBeGreaterThanOrEqual(785.7);
+            expect(top + item.height).toBeLessThanOrEqual(806);
+          } else {
+            expect(top).toBeGreaterThanOrEqual(111.9);
+            expect(top + item.height).toBeLessThanOrEqual(774);
+          }
+        }
+      }
+      const text = pages.join(" ");
+      for (let index = 1; index <= 40; index++)
+        expect(
+          text.match(
+            new RegExp(`Entry ${String(index).padStart(3, "0")}`, "g"),
+          ),
+        ).toHaveLength(1);
+      expect(pages[0]).toContain("same physical page.");
+      expect(pages[1]).toContain("Entry 040");
+      expect(pages[1]).not.toContain("Final summary");
+      expect(pages[2]).toContain("Final summary");
+      expect(pages[2]).toContain("1,000.00");
+      expect(pages[2]).toContain("SUMMARY-END");
+      expect(pages[2]).not.toContain("Verification appendix");
+      expect(pages[3]).toContain("Verification appendix");
+      expect(pages[3]).toContain("Manual verification entry");
+      expect(pages[3]).toContain("No outstanding entries.");
+      expect(pages[3]).toContain("APPENDIX-END");
+    } finally {
+      await task.destroy();
+    }
+  });
+
   it("composes selectable content, native links, local media and bounded lists", async () => {
     const canvas = createCanvas(280, 140);
     const context = canvas.getContext("2d");

--- a/packages/documents/src/primitives/primitives.pdf.test.tsx
+++ b/packages/documents/src/primitives/primitives.pdf.test.tsx
@@ -81,7 +81,7 @@ describe("shared PDF primitive frames", () => {
     }
   });
 
-  it("composes selectable content, native links, local media and bounded lists", async () => {
+  it("composes content, static forms, signatures and controlled repeated watermarks", async () => {
     const canvas = createCanvas(280, 140);
     const context = canvas.getContext("2d");
     context.fillStyle = "#eeeeee";
@@ -104,11 +104,14 @@ describe("shared PDF primitive frames", () => {
     const task = getDocument({ data: bytes.slice(), useSystemFonts: false });
     try {
       const document = await task.promise;
-      expect(document.numPages).toBe(1);
+      expect(document.numPages).toBe(2);
+      expect(await document.getFieldObjects()).toBeNull();
       const page = await document.getPage(1);
       const content = await page.getTextContent();
       const items = content.items.filter((item) => "str" in item);
       const text = items.map((item) => item.str).join(" ");
+      expect(text).toContain("DRAFT");
+      expect(text).toContain("SAMPLE");
       for (const expected of [
         "Core document components",
         "explicit emphasis",
@@ -154,6 +157,72 @@ describe("shared PDF primitive frames", () => {
       }
       const operators = await page.getOperatorList();
       expect(operators.fnArray).toContain(OPS.paintImageXObject);
+      const formPage = await document.getPage(2);
+      const formContent = await formPage.getTextContent();
+      const formItems = formContent.items.filter((item) => "str" in item);
+      const formText = formItems.map((item) => item.str).join(" ");
+      for (const label of [
+        "Review and sign-off",
+        "Draft",
+        "Review pending",
+        "Note",
+        "Complete before printing",
+        "Document reference",
+        "Purpose",
+        "Contact information",
+        "Full name (required)",
+        "elodie@example.com",
+        "14 avenue des Arts",
+        "Brazzaville",
+        "Telephone",
+        "Review details",
+        "DOC-026",
+        "25",
+        "Review date",
+        "Review notes",
+        "Prepared by",
+        "Élodie Mbemba",
+        "Editor",
+        "15 January 2026",
+        "Approved by",
+        "Morgan Lee",
+        "Reviewer",
+        "Witness signature",
+        "Collected by",
+        "Important",
+        "Static print elements only",
+        "DRAFT",
+      ])
+        expect(formText).toContain(label);
+      expect(formText).not.toContain("SAMPLE");
+      expect(await formPage.getAnnotations()).toHaveLength(0);
+      for (const item of formItems.filter((item) => item.str.trim())) {
+        expect(item.transform[4]).toBeGreaterThanOrEqual(35.9);
+        expect(item.transform[4]! + item.width).toBeLessThanOrEqual(559.38);
+        const top = formPage.view[3]! - item.transform[5]! - item.height;
+        expect(top).toBeGreaterThanOrEqual(35.9);
+        expect(top + item.height).toBeLessThanOrEqual(805.99);
+      }
+      const field = (label: string) =>
+        formItems.find((item) => item.str === label)!;
+      expect(field("Full name (required)").transform[5]).toBeCloseTo(
+        field("Email").transform[5]!,
+        1,
+      );
+      expect(field("Email").transform[4]).toBeGreaterThan(290);
+      expect(field("Reference").transform[5]).toBeCloseTo(
+        field("Copies").transform[5]!,
+        1,
+      );
+      expect(field("Copies").transform[5]).toBeCloseTo(
+        field("Review date").transform[5]!,
+        1,
+      );
+      expect(field("Review date").transform[4]).toBeGreaterThan(390);
+      expect(field("Prepared by").transform[5]).toBeCloseTo(
+        field("Approved by").transform[5]!,
+        1,
+      );
     } finally {
       await task.destroy();
     }

--- a/packages/documents/src/primitives/printable-data.ts
+++ b/packages/documents/src/primitives/printable-data.ts
@@ -1,0 +1,113 @@
+import { DocumentValidationError } from "../core/errors";
+
+export function assertPrintText(
+  value: string,
+  path: string,
+  maximum = 128,
+): void {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum)
+    invalidPrintData(
+      `Expected nonempty text of at most ${maximum} characters.`,
+      path,
+    );
+}
+
+export function invalidPrintData(message: string, path: string): never {
+  throw new DocumentValidationError([
+    { code: "INVALID_DATA", message, path: [path] },
+  ]);
+}
+
+export interface FormField {
+  id: string;
+  label: string;
+  value?: string;
+  required?: boolean;
+}
+
+export interface FormGroup {
+  id: string;
+  title: string;
+  columns?: 1 | 2 | 3;
+  fields: readonly FormField[];
+}
+
+export function assertFormGroups(groups: readonly FormGroup[]): void {
+  if (!Array.isArray(groups) || !groups.length || groups.length > 12)
+    invalidPrintData("A form needs one to twelve groups.", "groups");
+  const groupIds = new Set<string>();
+  const fieldIds = new Set<string>();
+  for (const group of groups) {
+    if (!group || typeof group !== "object")
+      invalidPrintData("Expected a form group.", "groups");
+    assertPrintText(group.id, "group.id");
+    assertPrintText(group.title, "group.title");
+    if (groupIds.has(group.id))
+      invalidPrintData("Group IDs must be unique.", "group.id");
+    groupIds.add(group.id);
+    if (group.columns !== undefined && ![1, 2, 3].includes(group.columns))
+      invalidPrintData(
+        "Groups support one, two or three columns.",
+        "group.columns",
+      );
+    if (!Array.isArray(group.fields) || !group.fields.length)
+      invalidPrintData("Every group needs fields.", "group.fields");
+    if (fieldIds.size + group.fields.length > 60)
+      invalidPrintData("A form supports at most 60 fields.", "group.fields");
+    for (const field of group.fields) {
+      if (!field || typeof field !== "object")
+        invalidPrintData("Expected a printable field.", "field");
+      assertPrintText(field.id, "field.id");
+      assertPrintText(field.label, "field.label");
+      if (fieldIds.has(field.id))
+        invalidPrintData("Field IDs must be unique across groups.", "field.id");
+      fieldIds.add(field.id);
+      if (field.value !== undefined && field.value !== "")
+        assertPrintText(field.value, "field.value", 2000);
+      if (field.required !== undefined && typeof field.required !== "boolean")
+        invalidPrintData("Required must be a boolean.", "field.required");
+    }
+  }
+}
+
+export interface Signer {
+  label: string;
+  name?: string;
+  role?: string;
+  date?: string;
+}
+
+export interface SignatureProps {
+  signers: readonly Signer[];
+  layout?: "stacked" | "inline";
+  space?: number;
+}
+
+export function assertSignature({
+  signers,
+  layout = "stacked",
+  space = 40,
+}: SignatureProps): void {
+  if (layout !== "stacked" && layout !== "inline")
+    invalidPrintData("Unknown signature layout.", "layout");
+  if (
+    !Array.isArray(signers) ||
+    signers.length < 1 ||
+    signers.length > 2 ||
+    (layout === "inline" && signers.length !== 1)
+  )
+    invalidPrintData(
+      "Use one or two signers, or one signer inline.",
+      "signers",
+    );
+  if (!Number.isFinite(space) || space < 24 || space > 96)
+    invalidPrintData("Signature writing space must be 24–96 points.", "space");
+  for (const signer of signers) {
+    if (!signer || typeof signer !== "object")
+      invalidPrintData("Expected a signer.", "signers");
+    assertPrintText(signer.label, "signer.label");
+    for (const key of ["name", "role", "date"] as const)
+      if (signer[key] !== undefined)
+        assertPrintText(signer[key], `signer.${key}`);
+  }
+}

--- a/packages/documents/src/primitives/signature.tsx
+++ b/packages/documents/src/primitives/signature.tsx
@@ -1,0 +1,63 @@
+import { View } from "@react-pdf/renderer";
+import { assertSignature, type SignatureProps } from "./printable-data";
+import { usePdfTheme } from "./theme-context";
+import { Text } from "./typography";
+
+export type { SignatureProps, Signer } from "./printable-data";
+
+export function Signature({
+  signers,
+  layout = "stacked",
+  space = 40,
+}: SignatureProps) {
+  const theme = usePdfTheme();
+  assertSignature({ signers, layout, space });
+  return (
+    <View wrap={false} style={{ flexDirection: "row", gap: theme.spacing.xl }}>
+      {signers.map((signer, index) => (
+        <View
+          key={index}
+          style={{
+            flex: 1,
+            minWidth: 0,
+            flexDirection: layout === "inline" ? "row" : "column",
+            gap: theme.spacing.sm,
+          }}
+        >
+          <View
+            style={
+              layout === "inline"
+                ? { height: space, justifyContent: "flex-end" }
+                : {}
+            }
+          >
+            <Text size="caption" weight="strong">
+              {signer.label}
+            </Text>
+          </View>
+          <View
+            style={{
+              ...(layout === "inline" ? { flex: 1 } : {}),
+              gap: theme.spacing.sm,
+            }}
+          >
+            <View
+              style={{
+                height: space,
+                borderBottomColor: theme.colors.text,
+                borderBottomWidth: 0.5,
+              }}
+            />
+            {signer.name ? <Text>{signer.name}</Text> : null}
+            {signer.role ? (
+              <Text size="caption" tone="muted">
+                {signer.role}
+              </Text>
+            ) : null}
+            {signer.date ? <Text size="caption">{signer.date}</Text> : null}
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/packages/documents/src/primitives/table-data.ts
+++ b/packages/documents/src/primitives/table-data.ts
@@ -1,0 +1,133 @@
+import { DOCUMENT_LIMITS } from "../core/contracts";
+import { DocumentValidationError } from "../core/errors";
+import { assertFlowBlockFits, type FlowFrame } from "./flow-layout";
+
+export interface TableColumn {
+  key: string;
+  label: string;
+  width: number;
+  align?: "left" | "right";
+}
+export type TableValue = string | number;
+export interface DataTableColumn<T> extends TableColumn {
+  cell(row: T): TableValue;
+}
+export interface PreparedTableRow {
+  key: string;
+  height: number;
+  cells: readonly TableValue[];
+}
+export const TABLE_LIMITS = { columns: 12, rows: 500 } as const;
+
+function invalid(message: string, path: readonly (string | number)[]): never {
+  throw new DocumentValidationError([
+    { code: "INVALID_DATA", message, path: ["table", ...path] },
+  ]);
+}
+
+export function assertTableColumns(columns: readonly TableColumn[]): void {
+  if (
+    !Array.isArray(columns) ||
+    !columns.length ||
+    columns.length > TABLE_LIMITS.columns
+  )
+    invalid("A table requires one to twelve columns.", ["columns"]);
+  const keys = new Set<string>();
+  let width = 0;
+  for (const [index, column] of columns.entries()) {
+    if (
+      !column ||
+      typeof column.key !== "string" ||
+      !column.key.trim() ||
+      column.key.length > 128 ||
+      keys.has(column.key) ||
+      typeof column.label !== "string" ||
+      !column.label.trim() ||
+      column.label.length > 128 ||
+      !Number.isFinite(column.width) ||
+      column.width <= 0 ||
+      (column.align !== undefined && !["left", "right"].includes(column.align))
+    )
+      invalid(
+        "Use unique column keys, bounded labels, positive percentage widths and left/right alignment.",
+        ["columns", index],
+      );
+    keys.add(column.key);
+    width += column.width;
+  }
+  if (Math.abs(width - 100) > 0.001)
+    invalid("Column percentage widths must total 100.", ["columns"]);
+}
+
+export function assertTableValue(
+  value: TableValue,
+  path: readonly (string | number)[],
+): void {
+  if (
+    (typeof value !== "string" && typeof value !== "number") ||
+    (typeof value === "number" && !Number.isFinite(value)) ||
+    (typeof value === "string" &&
+      value.length > DOCUMENT_LIMITS.generalStringCharacters)
+  )
+    invalid("Table cells require bounded strings or finite numbers.", path);
+}
+
+export function assertTableHeight(
+  height: number,
+  frame: FlowFrame,
+  minimum: number,
+  path: readonly (string | number)[],
+): void {
+  assertFlowBlockFits(height, frame, ["table", ...path]);
+  if (height < minimum)
+    throw new DocumentValidationError([
+      {
+        code: "LAYOUT_OVERFLOW",
+        message:
+          "The declared table height must include text, padding and borders.",
+        path: ["table", ...path],
+      },
+    ]);
+}
+
+export function prepareTableRows<T>(
+  columns: readonly DataTableColumn<T>[],
+  data: readonly T[],
+  rowKey: (row: T, index: number) => string,
+  rowHeight: (row: T, index: number) => number,
+  frame: FlowFrame,
+  minimum: number,
+): PreparedTableRow[] {
+  assertTableColumns(columns);
+  if (!Array.isArray(data) || data.length > TABLE_LIMITS.rows)
+    invalid("A data table supports at most 500 rows.", ["rows"]);
+  if (
+    typeof rowKey !== "function" ||
+    typeof rowHeight !== "function" ||
+    columns.some((column) => typeof column.cell !== "function")
+  )
+    invalid("Data table accessors must be trusted functions.", ["columns"]);
+  const keys = new Set<string>();
+  return data.map((row, index) => {
+    const key = rowKey(row, index);
+    if (
+      typeof key !== "string" ||
+      !key.trim() ||
+      key.length > 128 ||
+      keys.has(key)
+    )
+      invalid(
+        "Data table row keys must be unique non-empty strings of at most 128 characters.",
+        ["rows", index, "key"],
+      );
+    keys.add(key);
+    const height = rowHeight(row, index);
+    assertTableHeight(height, frame, minimum, ["rows", index, "height"]);
+    const cells = columns.map((column) => {
+      const value = column.cell(row);
+      assertTableValue(value, ["rows", index, column.key]);
+      return value;
+    });
+    return { key, height, cells };
+  });
+}

--- a/packages/documents/src/primitives/table.test.ts
+++ b/packages/documents/src/primitives/table.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { resolveFormat } from "../core/formats";
+import { createFlowFrame } from "./flow-layout";
+import { assertPageNumberFormat } from "./pagination";
+import {
+  assertTableColumns,
+  assertTableHeight,
+  prepareTableRows,
+  type TableColumn,
+} from "./table-data";
+
+const format = resolveFormat("a4");
+if (format.kind !== "fixed") throw new Error("Expected A4.");
+const frame = createFlowFrame(format, {
+  margin: 36,
+  header: { height: 64, gap: 12 },
+  footer: { height: 20, gap: 12 },
+});
+const columns = [
+  {
+    key: "name",
+    label: "Name",
+    width: 70,
+    cell: (row: { name: string; value: number }) => row.name,
+  },
+  {
+    key: "value",
+    label: "Value",
+    width: 30,
+    cell: (row: { name: string; value: number }) => row.value,
+  },
+];
+
+describe("table and pagination contracts", () => {
+  it("validates unique bounded columns and complete percentage widths", () => {
+    expect(() => assertTableColumns(columns)).not.toThrow();
+    for (const invalid of [
+      [],
+      [{ key: "a", label: "A", width: 0 }],
+      [{ key: "a", label: "A", width: NaN }],
+      [{ key: "a", label: "A", width: 50 }],
+      [
+        { key: "a", label: "A", width: 50 },
+        { key: "a", label: "B", width: 50 },
+      ],
+      [{ key: "a", label: " ", width: 100 }],
+      [{ key: "a", label: "A", width: 100, align: "middle" }],
+      Array.from({ length: 13 }, (_, index) => ({
+        key: String(index),
+        label: "A",
+        width: 100 / 13,
+      })),
+    ])
+      expect(() =>
+        assertTableColumns(invalid as readonly TableColumn[]),
+      ).toThrow();
+  });
+
+  it("retains typed cell values and rejects oversized rows, duplicate keys and invalid data", () => {
+    const rows = [
+      { name: "Élodie", value: 0 },
+      { name: "Second", value: 12 },
+    ];
+    expect(
+      prepareTableRows(
+        columns,
+        rows,
+        (row) => row.name,
+        () => 28,
+        frame,
+        28,
+      ),
+    ).toEqual([
+      { key: "Élodie", height: 28, cells: ["Élodie", 0] },
+      { key: "Second", height: 28, cells: ["Second", 12] },
+    ]);
+    expect(
+      prepareTableRows(
+        columns,
+        [],
+        () => "",
+        () => 28,
+        frame,
+        28,
+      ),
+    ).toEqual([]);
+    for (const badRows of [
+      [{ name: "a".repeat(2001), value: 1 }],
+      [{ name: "Bad", value: NaN }],
+      [{ name: "Bad", value: Infinity }],
+      Array.from({ length: 501 }, (_, index) => ({
+        name: String(index),
+        value: 1,
+      })),
+    ])
+      expect(() =>
+        prepareTableRows(
+          columns,
+          badRows,
+          (_, index) => String(index),
+          () => 28,
+          frame,
+          28,
+        ),
+      ).toThrow();
+    expect(() =>
+      prepareTableRows(
+        columns,
+        rows,
+        () => "same",
+        () => 28,
+        frame,
+        28,
+      ),
+    ).toThrow();
+    expect(() =>
+      prepareTableRows(
+        columns,
+        rows,
+        () => "",
+        () => 28,
+        frame,
+        28,
+      ),
+    ).toThrow();
+    expect(() =>
+      prepareTableRows(
+        columns,
+        rows,
+        (row) => row.name,
+        () => frame.body.height + 1,
+        frame,
+        28,
+      ),
+    ).toThrowError(expect.objectContaining({ code: "LAYOUT_OVERFLOW" }));
+  });
+
+  it("includes row padding and refuses a tall non-breaking row before rendering", () => {
+    expect(() =>
+      assertTableHeight(28, frame, 28, ["row", "height"]),
+    ).not.toThrow();
+    expect(() =>
+      assertTableHeight(frame.body.height, frame, 28, ["row", "height"]),
+    ).not.toThrow();
+    for (const height of [0, -1, 27, NaN, Infinity, frame.body.height + 0.1]) {
+      expect(() =>
+        assertTableHeight(height, frame, 28, ["row", "height"]),
+      ).toThrowError(expect.objectContaining({ code: "LAYOUT_OVERFLOW" }));
+    }
+  });
+
+  it("accepts bounded page-number formats with no unresolved placeholder syntax", () => {
+    for (const value of [
+      "{page}",
+      "Page {page} of {pages}",
+      "Ledger {page} / {pages}",
+    ])
+      expect(() => assertPageNumberFormat(value)).not.toThrow();
+    for (const value of [
+      "",
+      "{pages}",
+      "{page} {total}",
+      "{page",
+      "{page}" + "x".repeat(120),
+    ])
+      expect(() => assertPageNumberFormat(value)).toThrow();
+  });
+});

--- a/packages/documents/src/primitives/table.tsx
+++ b/packages/documents/src/primitives/table.tsx
@@ -16,6 +16,9 @@ export function FlowTableHeader({
   left = 0,
   top,
   width = "100%",
+  inline = false,
+  minHeight,
+  textStyle,
 }: {
   backgroundColor: string;
   borderColor: string;
@@ -24,10 +27,13 @@ export function FlowTableHeader({
   left?: number;
   top: number;
   width?: number | string;
+  inline?: boolean;
+  minHeight?: number;
+  textStyle?: TextProps["style"];
 }) {
   return (
     <View
-      fixed
+      fixed={!inline}
       style={{
         backgroundColor,
         borderBottomColor: borderColor,
@@ -36,24 +42,28 @@ export function FlowTableHeader({
         left,
         paddingBottom: 6,
         paddingTop: 6,
-        position: "absolute",
+        position: inline ? "relative" : "absolute",
         top,
         width,
+        ...(minHeight === undefined ? {} : { minHeight }),
       }}
     >
       {columns.map((column) => (
         <Text
           key={column.key}
-          style={{
-            color,
-            fontSize: 7,
-            fontWeight: 700,
-            letterSpacing: 0.4,
-            paddingHorizontal: 4,
-            textAlign: column.align ?? "left",
-            textTransform: "uppercase",
-            width: column.width,
-          }}
+          style={[
+            {
+              color,
+              fontSize: 7,
+              fontWeight: 700,
+              letterSpacing: 0.4,
+              paddingHorizontal: 4,
+              textAlign: column.align ?? "left",
+              textTransform: "uppercase",
+              width: column.width,
+            },
+            textStyle,
+          ]}
         >
           {column.label}
         </Text>
@@ -65,9 +75,11 @@ export function FlowTableHeader({
 export function FlowTableRow({
   borderColor,
   children,
+  minHeight = 28,
 }: {
   borderColor: string;
   children: ReactNode;
+  minHeight?: number;
 }) {
   return (
     <View
@@ -76,7 +88,7 @@ export function FlowTableRow({
         borderBottomColor: borderColor,
         borderBottomWidth: 0.5,
         flexDirection: "row",
-        minHeight: 28,
+        minHeight,
         paddingBottom: 7,
         paddingTop: 7,
       }}

--- a/packages/documents/src/primitives/watermark-layout.ts
+++ b/packages/documents/src/primitives/watermark-layout.ts
@@ -1,0 +1,61 @@
+import { DocumentValidationError } from "../core/errors";
+import type { LayoutBounds } from "./measurement";
+import { assertPrintText, invalidPrintData } from "./printable-data";
+
+export interface WatermarkProps {
+  text: string;
+  placement?: "top" | "center" | "bottom";
+  opacity?: number;
+  fontSize?: number;
+  repeat?: boolean;
+}
+
+export function getWatermarkLayout(
+  {
+    text,
+    placement = "center",
+    opacity = 0.08,
+    fontSize = 32,
+    repeat = true,
+  }: WatermarkProps,
+  body: LayoutBounds,
+): LayoutBounds {
+  assertPrintText(text, "text", 24);
+  if (!/^[\u0020-\u007e\u00c0-\u00ff]+$/.test(text))
+    invalidPrintData("Watermarks support printable Latin text only.", "text");
+  if (
+    !["top", "center", "bottom"].includes(placement) ||
+    typeof repeat !== "boolean"
+  )
+    invalidPrintData(
+      "Unknown watermark placement or repeat behavior.",
+      "watermark",
+    );
+  if (!Number.isFinite(opacity) || opacity < 0.02 || opacity > 0.2)
+    invalidPrintData("Watermark opacity must be 0.02–0.2.", "opacity");
+  if (!Number.isFinite(fontSize) || fontSize < 12 || fontSize > 48)
+    invalidPrintData("Watermark font size must be 12–48 points.", "fontSize");
+  // Deliberately conservative for qualified Latin fonts, not a text shaper.
+  const height = fontSize * 2;
+  if (text.length * fontSize * 1.5 > body.width || height > body.height)
+    throw new DocumentValidationError([
+      {
+        code: "LAYOUT_OVERFLOW",
+        message:
+          "The watermark envelope must fit the flow body. Shorten the label or choose a smaller explicit size.",
+        path: ["watermark"],
+      },
+    ]);
+  return {
+    x: body.x,
+    y:
+      body.y +
+      (placement === "top"
+        ? 0
+        : placement === "bottom"
+          ? body.height - height
+          : (body.height - height) / 2),
+    width: body.width,
+    height,
+  };
+}

--- a/packages/documents/src/primitives/watermark.tsx
+++ b/packages/documents/src/primitives/watermark.tsx
@@ -1,0 +1,43 @@
+import { Text as ReactPdfText } from "@react-pdf/renderer";
+import { useFlowFrame } from "./flow-context";
+import { usePdfTheme } from "./theme-context";
+import { getWatermarkLayout, type WatermarkProps } from "./watermark-layout";
+
+export type { WatermarkProps } from "./watermark-layout";
+
+// Place directly in DocumentFrame after body content, never inside a Stack.
+export function Watermark({
+  text,
+  placement = "center",
+  opacity = 0.08,
+  fontSize = 32,
+  repeat = true,
+}: WatermarkProps) {
+  const theme = usePdfTheme();
+  const { body } = useFlowFrame();
+  const bounds = getWatermarkLayout(
+    { text, placement, opacity, fontSize, repeat },
+    body,
+  );
+  return (
+    <ReactPdfText
+      fixed
+      style={{
+        position: "absolute",
+        left: bounds.x,
+        top: bounds.y,
+        width: bounds.width,
+        height: bounds.height,
+        textAlign: "center",
+        fontFamily: theme.fonts.heading,
+        fontWeight: theme.fonts.strongWeight,
+        fontSize,
+        color: theme.colors.text,
+        opacity,
+      }}
+      render={({ subPageNumber }) =>
+        repeat || subPageNumber === 1 ? text : null
+      }
+    />
+  );
+}

--- a/tests/consumers/registry.consumer.test.ts
+++ b/tests/consumers/registry.consumer.test.ts
@@ -296,9 +296,9 @@ describe("isolated registry consumers", () => {
     const browserSources = await listFiles(resolve(browserDirectory, "docn"));
     const nodeSources = await listFiles(resolve(nodeDirectory, "docn"));
     const installedSources = [...browserSources, ...nodeSources];
-    // S02b adds six content/validation modules to the S02a aggregate closure.
-    expect(browserSources).toHaveLength(48);
-    expect(nodeSources).toHaveLength(49);
+    // S02c adds five pagination/table modules to the S02b aggregate closure.
+    expect(browserSources).toHaveLength(53);
+    expect(nodeSources).toHaveLength(54);
     expect(
       installedSources.filter((file) =>
         /[\\/]primitives[\\/]qr-code\.ts$/.test(file),

--- a/tests/consumers/registry.consumer.test.ts
+++ b/tests/consumers/registry.consumer.test.ts
@@ -296,9 +296,9 @@ describe("isolated registry consumers", () => {
     const browserSources = await listFiles(resolve(browserDirectory, "docn"));
     const nodeSources = await listFiles(resolve(nodeDirectory, "docn"));
     const installedSources = [...browserSources, ...nodeSources];
-    // S02c adds five pagination/table modules to the S02b aggregate closure.
-    expect(browserSources).toHaveLength(53);
-    expect(nodeSources).toHaveLength(54);
+    // S02d adds six form/annotation modules to the S02c aggregate closure.
+    expect(browserSources).toHaveLength(59);
+    expect(nodeSources).toHaveLength(60);
     expect(
       installedSources.filter((file) =>
         /[\\/]primitives[\\/]qr-code\.ts$/.test(file),

--- a/tooling/registry/source-manifest.mjs
+++ b/tooling/registry/source-manifest.mjs
@@ -91,6 +91,11 @@ export const registrySourceManifest = {
         "packages/documents/src/primitives/measurement.ts",
         "packages/documents/src/primitives/qr-code.ts",
         "packages/documents/src/primitives/table.tsx",
+        "packages/documents/src/primitives/pagination.tsx",
+        "packages/documents/src/primitives/page-regions.tsx",
+        "packages/documents/src/primitives/table-data.ts",
+        "packages/documents/src/primitives/composable-table.tsx",
+        "packages/documents/src/primitives/data-table.tsx",
       ],
     },
     {

--- a/tooling/registry/source-manifest.mjs
+++ b/tooling/registry/source-manifest.mjs
@@ -96,6 +96,12 @@ export const registrySourceManifest = {
         "packages/documents/src/primitives/table-data.ts",
         "packages/documents/src/primitives/composable-table.tsx",
         "packages/documents/src/primitives/data-table.tsx",
+        "packages/documents/src/primitives/annotations.tsx",
+        "packages/documents/src/primitives/printable-data.ts",
+        "packages/documents/src/primitives/form.tsx",
+        "packages/documents/src/primitives/signature.tsx",
+        "packages/documents/src/primitives/watermark-layout.ts",
+        "packages/documents/src/primitives/watermark.tsx",
       ],
     },
     {


### PR DESCRIPTION
## Summary

- add reusable `KeepTogether`, `PageBreak`, repeated page regions, final page numbering, `Table`, and typed `DataTable` primitives
- reuse the existing flow-table helpers and require explicit bounded measurements for non-breaking rows and groups
- add neutral printable `Alert`, `Badge`, `Form`, `Signature`, and `Watermark` components
- keep these elements static and printable without introducing DOM controls, AcroForms, cryptographic signatures, or document-protection claims

## Scope

This PR contains L12 S02c and S02d only. It excludes graphs, barcodes, individual registry entries, public component detail pages, and the remaining lot work.

Part of #16. It does not close the lot.

## Verification

### S02c — pagination and tables

- `pnpm test:unit table.test measurement registry` — 3 files, 12 tests passed
- `DOCN_WRITE_PDF_ARTIFACTS=1 pnpm test:pdf primitives invoice` — 2 files, 6 tests passed
- Poppler invoice comparison — 4 PDFs and 7 pages identical
- four-page pagination/table specimen visually inspected
- quality, registry, consumer, build, documentation, and diff checks passed

### S02d — printable forms and annotations

- `pnpm test:unit content.test measurement registry` — 3 files, 15 tests passed
- focused content validation — 1 file, 7 tests passed
- `DOCN_WRITE_PDF_ARTIFACTS=1 pnpm test:pdf primitives` — 1 file, 3 tests passed
- two-page content specimen visually inspected after the final alignment correction
- quality, registry, consumer, build, documentation, and diff checks passed

No deployment, publication, or automatic merge is requested.
