### PR TITLE
docs(contributing): complete L12 template workflow and SEO governance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,20 @@ Start a working branch from `dev` using the branch name in the lot. Supported pr
 
 Both branches require PRs and the `branch-policy` check. No direct pushes, force pushes, deletions or bypasses. Keep the planned atomic commits and use merge commits, never squash. Merges require maintainer authorization; no auto-merge. Additional CI checks become required when their actual suites are introduced.
 
+## Template contributions
+
+Read the public [Creating templates](apps/www/src/content/docs/guide-content.ts) guide before changing a composition. It defines the required schema, metadata, fixture, registry, generated preview, licensing, review, compatibility and versioning workflow.
+
+A template must remain one source of truth. The catalog, gallery preview, PDF export and registry derive from its registered `TemplateDefinition`. A new composition in an existing family must not require playground-core changes or a copied family implementation.
+
+### Template pull request checklist
+
+- Use English for source, documentation, UI copy, comments, commits, issues and pull requests.
+- Preserve existing work and keep each commit to one coherent, tested intention.
+- State asset provenance and redistribution terms. Do not submit copied brands or unlicensed assets.
+- Describe supported formats, data/API changes, version changes, visual evidence, focused tests and known limitations.
+- Complete the repository pull request checklist. Never weaken checks or regenerate references only to make CI pass.
+
 ## Verification without redundant tests
 
 Use the lowest sufficient scope from [TESTING](docs/TESTING.md). Documentation changes need link/consistency checks and `git diff --check`, not PDF or browser suites. For branch policy changes run:
@@ -20,7 +34,15 @@ Use the lowest sufficient scope from [TESTING](docs/TESTING.md). Documentation c
 node --test tooling/github/branch-policy.test.mjs
 ```
 
-Application commands such as `pnpm validate`, `test:pdf` and `test:e2e` are introduced in their planned lots. They are not available merely because a document mentions them. Never claim an unexecuted check passed.
+For a template contribution, run the lowest sufficient targeted test during development. Before review, run:
+
+```sh
+corepack pnpm validate
+corepack pnpm build
+corepack pnpm verify:docs
+```
+
+When PDF source, geometry, data rendering or assets change, also run the affected PDF test named by the lot or test plan. Documentation-only changes do not require the full PDF suite.
 
 ## Issue and Project tracking
 

--- a/apps/www/src/app/(site)/components/[slug]/page.tsx
+++ b/apps/www/src/app/(site)/components/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { DocumentationShell } from "@/features/docs/documentation-shell";
 import { readDocumentationCatalog } from "@/features/docs/catalog-data";
 import { PdfExampleViewer } from "@/features/docs/pdf-example-viewer";
 import { ComponentInstall } from "@/features/docs/component-install";
+import { createPageMetadata } from "@/lib/site-metadata";
 
 export const dynamicParams = false;
 export function generateStaticParams() {
@@ -19,10 +20,12 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const entry = componentCatalog.find((entry) => entry.slug === slug);
-  return {
+  if (!entry) notFound();
+  return createPageMetadata({
     title: `${entry?.title ?? "Component"} — docn-ui`,
-    description: entry?.description,
-  };
+    description: entry.description,
+    path: `/components/${entry.slug}/`,
+  });
 }
 const heading = "mb-4 scroll-m-24 text-xl font-semibold tracking-tight";
 

--- a/apps/www/src/app/(site)/components/page.tsx
+++ b/apps/www/src/app/(site)/components/page.tsx
@@ -2,12 +2,14 @@ import Link from "next/link";
 import { componentCatalog } from "@docn-ui/documents/catalog/components";
 import { DocsArticle } from "@/features/docs/docs-article";
 import { DocumentationShell } from "@/features/docs/documentation-shell";
+import { createPageMetadata } from "@/lib/site-metadata";
 
-export const metadata = {
+export const metadata = createPageMetadata({
   title: "Components — docn-ui",
   description:
     "Explore PDF components, real previews, source code and typed props.",
-};
+  path: "/components/",
+});
 
 function ComponentLink({
   slug,

--- a/apps/www/src/app/(site)/docs/[slug]/page.tsx
+++ b/apps/www/src/app/(site)/docs/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { findGuide, guideIndex } from "@/content/docs/guide-index";
 import { GuideArticle } from "@/features/docs/guide-article";
+import { createPageMetadata } from "@/lib/site-metadata";
 
 export const dynamicParams = false;
 
@@ -16,7 +17,11 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const guide = findGuide((await params).slug);
   if (!guide) notFound();
-  return { title: `${guide.title} — docn-ui`, description: guide.description };
+  return createPageMetadata({
+    title: `${guide.title} — docn-ui`,
+    description: guide.description,
+    path: `/docs/${guide.slug}/`,
+  });
 }
 
 export default async function GuidePage({

--- a/apps/www/src/app/(site)/docs/getting-started/page.tsx
+++ b/apps/www/src/app/(site)/docs/getting-started/page.tsx
@@ -1,13 +1,14 @@
-import type { Metadata } from "next";
 import Link from "next/link";
 import { DocsArticle } from "@/features/docs/docs-article";
 import { DocumentationShell } from "@/features/docs/documentation-shell";
+import { createPageMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: "Getting started — docn-ui",
   description:
     "Choose a template, install its source and render independently with local assets.",
-};
+  path: "/docs/getting-started/",
+});
 
 export default function GettingStartedPage() {
   return (

--- a/apps/www/src/app/(site)/docs/page.tsx
+++ b/apps/www/src/app/(site)/docs/page.tsx
@@ -1,14 +1,15 @@
-import type { Metadata } from "next";
 import Link from "next/link";
 import { DocsArticle } from "@/features/docs/docs-article";
 import { DocumentationShell } from "@/features/docs/documentation-shell";
 import { guideIndex } from "@/content/docs/guide-index";
+import { createPageMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: "Documentation — docn-ui",
   description:
     "Install, render and adapt source-owned PDF documents in an existing shadcn project.",
-};
+  path: "/docs/",
+});
 
 export default function DocsPage() {
   return (

--- a/apps/www/src/app/(site)/formats/page.tsx
+++ b/apps/www/src/app/(site)/formats/page.tsx
@@ -2,12 +2,14 @@ import Link from "next/link";
 import { DocsArticle, CodeBlock } from "@/features/docs/docs-article";
 import { DocumentationShell } from "@/features/docs/documentation-shell";
 import { readDocumentationCatalog } from "@/features/docs/catalog-data";
+import { createPageMetadata } from "@/lib/site-metadata";
 
-export const metadata = {
+export const metadata = createPageMetadata({
   title: "Formats — docn-ui",
   description:
     "Supported PDF page sizes, safe areas and template compatibility in millimeters.",
-};
+  path: "/formats/",
+});
 
 export default async function FormatsPage() {
   const { formats } = await readDocumentationCatalog();

--- a/apps/www/src/app/(site)/page.tsx
+++ b/apps/www/src/app/(site)/page.tsx
@@ -1,6 +1,14 @@
 import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
+import { createPageMetadata } from "@/lib/site-metadata";
 import { cn } from "@/lib/utils";
+
+export const metadata = createPageMetadata({
+  title: "docn-ui — PDF templates, in your codebase",
+  description:
+    "Install source-owned PDF templates, edit them locally and render in the browser.",
+  path: "/",
+});
 
 export default function HomePage() {
   return (

--- a/apps/www/src/app/(site)/templates/page.tsx
+++ b/apps/www/src/app/(site)/templates/page.tsx
@@ -1,11 +1,12 @@
-import type { Metadata } from "next";
 import { TemplateCatalog } from "@/features/catalog/template-catalog";
+import { createPageMetadata } from "@/lib/site-metadata";
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: "PDF template catalog — docn-ui",
   description:
     "Browse source-owned PDF template families built from docn-ui components.",
-};
+  path: "/templates/",
+});
 
 export default function TemplatesPage() {
   return <TemplateCatalog />;

--- a/apps/www/src/app/(site)/themes/page.tsx
+++ b/apps/www/src/app/(site)/themes/page.tsx
@@ -3,12 +3,14 @@ import { DocsArticle, CodeBlock } from "@/features/docs/docs-article";
 import { DocumentationShell } from "@/features/docs/documentation-shell";
 import { readDocumentationCatalog } from "@/features/docs/catalog-data";
 import { PdfExampleViewer } from "@/features/docs/pdf-example-viewer";
+import { createPageMetadata } from "@/lib/site-metadata";
 
-export const metadata = {
+export const metadata = createPageMetadata({
   title: "Themes — docn-ui",
   description:
     "Compare Neutral, Editorial and Bold PDF themes on identical document content.",
-};
+  path: "/themes/",
+});
 
 export default async function ThemesPage() {
   const { themes } = await readDocumentationCatalog();

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -1,12 +1,18 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import { ThemeProvider } from "@/features/theme/theme-provider";
+import { siteIsIndexable, siteUrl } from "@/lib/site-metadata";
 import "./globals.css";
 
 export const metadata: Metadata = {
+  metadataBase: siteUrl,
   title: "docn-ui — PDF templates, in your codebase",
   description:
     "A source-owned PDF template toolkit in development. Follow the public implementation plan.",
+  robots: {
+    index: siteIsIndexable,
+    follow: siteIsIndexable,
+  },
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/www/src/app/not-found.tsx
+++ b/apps/www/src/app/not-found.tsx
@@ -1,4 +1,9 @@
 import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 export default function NotFound() {
   return (

--- a/apps/www/src/app/robots.ts
+++ b/apps/www/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { siteIsIndexable, siteUrl } from "@/lib/site-metadata";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: siteIsIndexable
+      ? { userAgent: "*", allow: "/", disallow: ["/generated/", "/r/"] }
+      : { userAgent: "*", disallow: "/" },
+    sitemap: new URL("/sitemap.xml", siteUrl).href,
+  };
+}

--- a/apps/www/src/app/sitemap.ts
+++ b/apps/www/src/app/sitemap.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+import { knownPages } from "@/features/docs/page-index";
+import { siteUrl } from "@/lib/site-metadata";
+
+export const dynamic = "force-static";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [...new Set(knownPages.map(({ href }) => href))]
+    .sort()
+    .map((path) => ({ url: new URL(path, siteUrl).href }));
+}

--- a/apps/www/src/content/docs/guide-content.ts
+++ b/apps/www/src/content/docs/guide-content.ts
@@ -396,6 +396,107 @@ export const guideContent: Record<GuideSlug, readonly GuideSection[]> = {
       ],
     },
   ],
+  "creating-templates": [
+    {
+      id: "single-source",
+      title: "Add one source-owned composition",
+      blocks: [
+        {
+          type: "paragraph",
+          text: "A template is one composition that supplies the catalog, gallery preview, PDF export and registry. Add it to the existing family in packages/documents/src/templates instead of copying a family or changing playground core. Create a new family or form registry only when the document data contract is genuinely different.",
+        },
+        {
+          type: "list",
+          items: [
+            "Define or reuse a validated data schema and exported TypeScript type. Keep calculations and normalized values outside the visual composition.",
+            "Create the composition with @react-pdf/renderer primitives and docn-ui document components only. Do not use DOM elements, Tailwind classes or site components in PDF source.",
+            "Provide deterministic sample data as the fixture rendered by the catalog. Use realistic edge lengths and stable dates, totals and identifiers.",
+            "Export one TemplateDefinition from the family index with a stable ID, version, title, description, tags, family, formats, sides, capabilities, source path and license metadata.",
+            "Register the definition in packages/documents/src/templates/index.ts. The generator derives catalog records, previews and registry artifacts from that source.",
+          ],
+        },
+        {
+          type: "code",
+          label: "Generate derived template artifacts",
+          highlight: false,
+          code: "corepack pnpm generate:templates\ncorepack pnpm generate:registry",
+        },
+      ],
+    },
+    {
+      id: "identity-and-license",
+      title: "Use an original identity and permitted assets",
+      blocks: [
+        {
+          type: "paragraph",
+          text: "Every contribution needs an original visual identity and traceable asset provenance. Do not reproduce a third-party logo, brand, document or marketplace preview. A reference may inform layout critique, but the shipped composition, marks, copy and imagery must be independently created or licensed for redistribution.",
+        },
+        {
+          type: "list",
+          items: [
+            "Record the template license in metadata and retain required attribution or license files beside imported assets.",
+            "Prefer repository-owned vectors and generated fixtures. Record the generator, prompt or source and redistribution terms for images.",
+            "Do not add a dependency to draw a single shape. A new dependency requires its purpose, license and bundle impact to be reviewed.",
+            "Keep user-provided images behind the existing validated local-image contract; never introduce arbitrary remote URLs.",
+          ],
+        },
+      ],
+    },
+    {
+      id: "review-checklist",
+      title: "Review visual and data quality",
+      blocks: [
+        {
+          type: "list",
+          items: [
+            "Compare every side and supported format at actual dimensions. Check safe areas, alignment, clipping, overflow, page count, whitespace and rounded or edge-to-edge artwork.",
+            "Verify headings, labels, locale, dates, monetary values, subtotals, taxes and totals against the fixture. Machine-readable codes must encode the displayed value and remain decodable in the final PDF.",
+            "Exercise one representative long-value or dense-data case at the lowest sufficient test scope. Do not create a Cartesian product of variants.",
+            "Inspect the generated gallery image and detailed PDF preview. Never edit generated previews to hide a source-layout defect.",
+            "Confirm keyboard access and reduced-motion behavior for any website interaction changed by the contribution.",
+          ],
+        },
+      ],
+    },
+    {
+      id: "compatibility-and-versioning",
+      title: "Version contract changes deliberately",
+      blocks: [
+        {
+          type: "paragraph",
+          text: "A visual correction that preserves the accepted data contract increments the template patch version. Additive optional data or a new compatible format increments the minor version. Removing or renaming fields, changing their meaning, or changing physical output incompatibly requires a major version and migration notes. Never replace an immutable published registry item with different content.",
+        },
+        {
+          type: "list",
+          items: [
+            "Call out format changes in the pull request: page dimensions, orientation, sides, bleed, safe area and pagination behavior.",
+            "Call out API changes: schema fields, defaults, calculations, component props and exported types. Include migration guidance for any incompatibility.",
+            "Keep one coherent behavior and its focused tests in each commit. Update catalog evidence in the same contribution.",
+          ],
+        },
+      ],
+    },
+    {
+      id: "verification",
+      title: "Verify and submit the contribution",
+      blocks: [
+        {
+          type: "paragraph",
+          text: "Run the lowest sufficient targeted test while developing, then validate the complete lightweight suite and static documentation before review. Run the affected PDF test when composition, geometry, data rendering or assets changed; a documentation-only edit does not require the full PDF suite.",
+        },
+        {
+          type: "code",
+          label: "Required contribution checks",
+          highlight: false,
+          code: "corepack pnpm validate\ncorepack pnpm build\ncorepack pnpm verify:docs\n# When PDF source or assets changed:\ncorepack pnpm test:pdf -- <affected test file>",
+        },
+        {
+          type: "paragraph",
+          text: "Open a work-branch pull request to dev. Describe the template, source and license provenance, supported formats, API or version changes, focused tests, generated visual evidence and known limitations. Reviewers should be able to trace every catalog surface back to the one registered TemplateDefinition.",
+        },
+      ],
+    },
+  ],
   limitations: [
     {
       id: "fonts-and-scripts",

--- a/apps/www/src/content/docs/guide-index.ts
+++ b/apps/www/src/content/docs/guide-index.ts
@@ -42,6 +42,12 @@ export const guideIndex = [
       "Review upstream changes while keeping ownership of your installed components.",
   },
   {
+    slug: "creating-templates",
+    title: "Creating templates",
+    description:
+      "Contribute a source-owned template with qualified data, metadata, previews and review evidence.",
+  },
+  {
     slug: "limitations",
     title: "Limitations",
     description:

--- a/apps/www/src/features/docs/page-index.ts
+++ b/apps/www/src/features/docs/page-index.ts
@@ -1,3 +1,6 @@
+import { guideIndex } from "@/content/docs/guide-index";
+import { componentCatalog } from "@docn-ui/documents/catalog/components";
+
 export type KnownPage = {
   title: string;
   description: string;
@@ -61,5 +64,3 @@ export const knownPages: readonly KnownPage[] = [
     section: "Documentation",
   },
 ] as const;
-import { guideIndex } from "@/content/docs/guide-index";
-import { componentCatalog } from "@docn-ui/documents/catalog/components";

--- a/apps/www/src/lib/site-metadata.ts
+++ b/apps/www/src/lib/site-metadata.ts
@@ -1,0 +1,40 @@
+import type { Metadata } from "next";
+
+const localSiteUrl = "http://127.0.0.1:3000";
+
+function readSiteUrl() {
+  const configured = process.env.SITE_URL?.trim();
+  if (!configured) return new URL(localSiteUrl);
+  const url = new URL(configured);
+  if (
+    url.protocol !== "https:" &&
+    !["127.0.0.1", "localhost"].includes(url.hostname)
+  )
+    throw new Error("SITE_URL must use HTTPS unless it targets loopback.");
+  if (url.pathname !== "/" || url.search || url.hash)
+    throw new Error(
+      "SITE_URL must be an origin without a path, query, or fragment.",
+    );
+  return url;
+}
+
+export const siteUrl = readSiteUrl();
+export const siteIsIndexable =
+  Boolean(process.env.SITE_URL?.trim()) &&
+  process.env.DOCN_ALLOW_INDEXING === "true";
+
+export function createPageMetadata({
+  title,
+  description,
+  path,
+}: {
+  title: string;
+  description: string;
+  path: `/${string}`;
+}): Metadata {
+  return {
+    title,
+    description,
+    alternates: { canonical: new URL(path, siteUrl) },
+  };
+}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -32,6 +32,8 @@ Technical default: portable static build (`apps/www/out`). The host remains unco
 
 L15 provides a preview if the destination is authorized; otherwise provide a procedure and clearly labeled local HTTP validation. `SITE_URL` controls canonical URLs, sitemap, and registry; a release build rejects placeholder URLs. Previews are not indexed.
 
+Static builds emit a canonical URL and sitemap entry for every public page. Without `SITE_URL`, canonicals use the loopback development origin and the complete site emits `noindex, nofollow` plus `Disallow: /`. A publication candidate becomes indexable only when it has an authorized `SITE_URL` and `DOCN_ALLOW_INDEXING=true`. Generated preview assets and development registry paths remain excluded from crawlers. Do not enable indexing merely to test a preview deployment.
+
 Long cache lifetimes for hashed assets and immutable versioned registry files; current HTML/catalog can be revalidated. Registry JSON/public archives needed by consumers are accessible without a session; configure CORS where documented use requires it, not as general permission for exfiltration.
 
 Headers: correct MIME types, `nosniff`, Referrer-Policy, CSP derived from the actual build, local worker-src/font-src. Measure needs for `blob:` and Next inline scripts; do not use blanket `unsafe-*` allowances for convenience. The host applies static-export headers. Publication requires TLS.

--- a/docs/implementation/github.json
+++ b/docs/implementation/github.json
@@ -644,8 +644,8 @@
       "issueUrl": "https://github.com/Osiris-Balonga/docn-ui/issues/16",
       "itemId": "PVTI_lAHOCZDjCM4BhyZuzg4fVmY",
       "pullRequest": {
-        "number": 38,
-        "url": "https://github.com/Osiris-Balonga/docn-ui/pull/38"
+        "number": 40,
+        "url": "https://github.com/Osiris-Balonga/docn-ui/pull/40"
       },
       "initialized": true
     },

--- a/docs/implementation/lots/L12-documentation.md
+++ b/docs/implementation/lots/L12-documentation.md
@@ -1,6 +1,6 @@
 # L12 — Documentation, components, formats, and themes
 
-Status: **verified locally**. Final branch: `docs/l12-contribution-seo`, based on `dev` commit `8cdf4837cf36f3134b236b1ad843cc17daf1db0e`. The maintainer authorized PR #31's merge and L12 implementation on 2026-08-31, then authorized validation and merge of subsequent pull requests on 2026-09-01.
+Status: **in review** in PR #40. Final branch: `docs/l12-contribution-seo`, based on `dev` commit `8cdf4837cf36f3134b236b1ad843cc17daf1db0e`. The maintainer authorized PR #31's merge and L12 implementation on 2026-08-31, then authorized validation and merge of subsequent pull requests on 2026-09-01.
 
 Dependencies: L11. Requirements: FR-02, FR-13, FR-15, FR-16, FR-17.
 

--- a/docs/implementation/lots/L12-documentation.md
+++ b/docs/implementation/lots/L12-documentation.md
@@ -1,6 +1,6 @@
 # L12 — Documentation, components, formats, and themes
 
-Status: **in progress**. Branch: `feat/documentation-catalog`, based on merged L11 commit `a342433e0902935a454d8ef04a85cb508a765f4a`. The maintainer authorized PR #31's merge and L12 implementation on 2026-08-31.
+Status: **verified locally**. Final branch: `docs/l12-contribution-seo`, based on `dev` commit `8cdf4837cf36f3134b236b1ad843cc17daf1db0e`. The maintainer authorized PR #31's merge and L12 implementation on 2026-08-31, then authorized validation and merge of subsequent pull requests on 2026-09-01.
 
 Dependencies: L11. Requirements: FR-02, FR-13, FR-15, FR-16, FR-17.
 
@@ -125,9 +125,9 @@ L12-S02 is split into S02a–S02h because the new request introduces real PDF be
 
 ### L12-S03 — `docs(contributing): define template contribution and review workflow`
 
-- [ ] Template contribution guide: schema/metadata/composition/fixture/registry/preview and a test in the appropriate scope.
-- [ ] Visual/data quality checklist, licenses, format/API changes, and versioning.
-- [ ] Include all documentation in search, titles/descriptions/canonical URLs, and sitemap; preview URLs must not be indexable.
+- [x] Template contribution guide: schema/metadata/composition/fixture/registry/preview and a test in the appropriate scope.
+- [x] Visual/data quality checklist, licenses, format/API changes, and versioning.
+- [x] Include all documentation in search, titles/descriptions/canonical URLs, and sitemap; preview URLs must not be indexable.
 
 **Acceptance:** Contributors can add a composition without changing playground core or copying an entire family.
 

--- a/docs/implementation/status.json
+++ b/docs/implementation/status.json
@@ -299,10 +299,10 @@
     {
       "id": "L12",
       "file": "lots/L12-documentation.md",
-      "state": "in_progress",
+      "state": "verified_local",
       "dependsOn": ["L11"],
-      "branch": "feat/l12-component-variants",
-      "baseCommit": "a342433e0902935a454d8ef04a85cb508a765f4a",
+      "branch": "docs/l12-contribution-seo",
+      "baseCommit": "8cdf4837cf36f3134b236b1ad843cc17daf1db0e",
       "actualCommits": [
         "901907af6a08f40d32e40a7f0dc7b63cac1c3e52",
         "6c8563b8a10de329d0aac10a85f9d509699dffbc",
@@ -331,7 +331,8 @@
         "c0ea41f54b530452cfefa06ff3a700106bb3f2dd",
         "54bcaea7d1c62d7b253178be213850ef89867390",
         "6b84c374305eef7daf5d145c60eea6cf60a20215",
-        "dce3332f9442c1d75e026cdf4ef628e0a0bad69f"
+        "dce3332f9442c1d75e026cdf4ef628e0a0bad69f",
+        "6cfdc872a8d0ab98c1ea3d75c96ea3fddca2acb5"
       ],
       "evidence": "../qa/L12.md",
       "blocker": null

--- a/docs/implementation/status.json
+++ b/docs/implementation/status.json
@@ -299,7 +299,7 @@
     {
       "id": "L12",
       "file": "lots/L12-documentation.md",
-      "state": "verified_local",
+      "state": "in_review",
       "dependsOn": ["L11"],
       "branch": "docs/l12-contribution-seo",
       "baseCommit": "8cdf4837cf36f3134b236b1ad843cc17daf1db0e",
@@ -332,7 +332,8 @@
         "54bcaea7d1c62d7b253178be213850ef89867390",
         "6b84c374305eef7daf5d145c60eea6cf60a20215",
         "dce3332f9442c1d75e026cdf4ef628e0a0bad69f",
-        "6cfdc872a8d0ab98c1ea3d75c96ea3fddca2acb5"
+        "6cfdc872a8d0ab98c1ea3d75c96ea3fddca2acb5",
+        "ed900469b6843e05a7276ed3da97aac40d6a00a3"
       ],
       "evidence": "../qa/L12.md",
       "blocker": null

--- a/docs/qa/L12.md
+++ b/docs/qa/L12.md
@@ -476,7 +476,7 @@ No dependency, lockfile, server route, deployment or release change is included.
 
 ## S03 — template contribution and static SEO governance
 
-Implementation and focused tests: `6cfdc87`. L12 is **verified locally** and ready for connected review.
+Implementation and focused tests: `6cfdc87`. Tracking commit: `ed90046`. L12 is **in review** in PR #40 after successful local verification.
 
 The public Creating templates guide and root contribution guide now define the single-source template workflow: validated schema and type, PDF composition, deterministic fixture, complete metadata, registration, generated previews, original identity and licensed assets. Review guidance covers actual dimensions, safe areas, overflow, values, codes, generated evidence, compatibility, formats, API changes and patch/minor/major template versioning. An existing-family contribution does not require playground-core changes or a copied family implementation.
 

--- a/docs/qa/L12.md
+++ b/docs/qa/L12.md
@@ -473,3 +473,29 @@ Implementation and behavior commit: `dce3332`. The shared detailed reader now us
 | `git diff --check`                     | Passed.                                                                                                                                                                                                                                 |
 
 No dependency, lockfile, server route, deployment or release change is included. This correction is ready for the already authorized PR update and merge; L12 remains **in progress** because S03 has not started.
+
+## S03 — template contribution and static SEO governance
+
+Implementation and focused tests: `6cfdc87`. L12 is **verified locally** and ready for connected review.
+
+The public Creating templates guide and root contribution guide now define the single-source template workflow: validated schema and type, PDF composition, deterministic fixture, complete metadata, registration, generated previews, original identity and licensed assets. Review guidance covers actual dimensions, safe areas, overflow, values, codes, generated evidence, compatibility, formats, API changes and patch/minor/major template versioning. An existing-family contribution does not require playground-core changes or a copied family implementation.
+
+The typed guide index remains the shared source for documentation navigation and search. A parity test now covers every guide route in both surfaces. Every public static page supplies a title, description and canonical URL. The sitemap derives from the same public page index. Unconfigured builds emit `noindex, nofollow` and `Disallow: /`; indexing requires both an authorized `SITE_URL` and `DOCN_ALLOW_INDEXING=true`. Generated preview and development-registry paths remain excluded when indexing is enabled.
+
+### Executed checks
+
+| Check                                                        | Actual result                                                                                                                                           |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm exec vitest run tooling/docs/source-reference.test.ts` | Passed, 1 file / 4 cases, including guide search/navigation parity.                                                                                     |
+| `pnpm validate`                                              | Passed with exact pnpm 11.24.0: formatting, lint, workspace/root TypeScript and 17 files / 62 unit, component and integration tests.                    |
+| `pnpm build`                                                 | Passed: 48 statically generated routes, 18 template PDFs / 21 preview pages, 28 component PDFs / 3 theme PDFs, 62 registry items and 5 verified assets. |
+| `pnpm verify:docs`                                           | Passed: 44 public pages, titles, descriptions, canonicals, sitemap parity, preview noindex policy and 2,555 local links including static anchors.       |
+| `git diff --check`                                           | Passed.                                                                                                                                                 |
+
+### Corrections and boundaries
+
+The first static build exposed Next.js export's requirement that metadata routes declare `dynamic = "force-static"`; both routes now do so and the rebuilt export passes. Expanding the link checker to every public HTML page also exposed a client-controlled template-family fragment that is not present in the initial static DOM. Static fragment validation remains on documentation, component, format and theme content, while all public pages receive link-target, heading and SEO checks.
+
+The Codex runtime initially resolved pnpm 11.19.0 inside nested scripts although the repository requires 11.24.0. A temporary Corepack shim outside the repository made every recorded command use pnpm 11.24.0; no global installation or project file was changed. The known PDF.js standard-font warnings during template preview generation remain non-fatal and unchanged.
+
+No PDF suite was run because S03 changes documentation and static metadata only, as required by the lot. No host, license, public URL, publication or deployment was selected. The loopback canonical origin in local artifacts is deliberately non-indexable and is not a production claim.

--- a/tooling/docs/source-reference.test.ts
+++ b/tooling/docs/source-reference.test.ts
@@ -5,6 +5,7 @@ import { componentCatalog } from "../../packages/documents/src/catalog/component
 import { componentRegistryItems } from "../registry/component-items.mjs";
 import { knownPages } from "../../apps/www/src/features/docs/page-index";
 import { docsNavigation } from "../../apps/www/src/features/docs/navigation";
+import { guideIndex } from "../../apps/www/src/content/docs/guide-index";
 
 const root = fileURLToPath(new URL("../..", import.meta.url));
 
@@ -16,6 +17,15 @@ test("every public component has one registry item, searchable route and sidebar
   const navigation = docsNavigation.flatMap((group) => group.items);
   for (const { slug } of componentCatalog) {
     const href = `/components/${slug}/`;
+    expect(knownPages.filter((page) => page.href === href)).toHaveLength(1);
+    expect(navigation.filter((page) => page.href === href)).toHaveLength(1);
+  }
+});
+
+test("every guide has one searchable route and sidebar link", () => {
+  const navigation = docsNavigation.flatMap((group) => group.items);
+  for (const guide of guideIndex) {
+    const href = `/docs/${guide.slug}/`;
     expect(knownPages.filter((page) => page.href === href)).toHaveLength(1);
     expect(navigation.filter((page) => page.href === href)).toHaveLength(1);
   }

--- a/tooling/docs/verify-links.mjs
+++ b/tooling/docs/verify-links.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFile, readdir, stat } from "node:fs/promises";
-import { dirname, join, resolve, sep } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { JSDOM } from "jsdom";
 
 const output = resolve(import.meta.dirname, "../../apps/www/out");
@@ -34,13 +34,10 @@ async function readDocument(file) {
 }
 
 let linkCount = 0;
-const pages = (
-  await Promise.all(
-    ["docs", "components", "formats", "themes"].map((path) =>
-      htmlFiles(join(output, path)),
-    ),
-  )
-).flat();
+const pages = (await htmlFiles(output)).filter((file) => {
+  const path = relative(output, file).split(sep).join("/");
+  return !/^(404(?:\/|\.html$)|_not-found\/)/.test(path);
+});
 assert.ok(
   pages.length > 0,
   "Build the site before checking documentation links.",
@@ -55,6 +52,23 @@ for (const file of pages) {
     origin,
   );
   const document = await readDocument(file);
+  const canonical = document.querySelector('link[rel="canonical"]')?.href;
+  assert.ok(canonical, `${url.pathname}: missing canonical URL.`);
+  assert.equal(
+    new URL(canonical).pathname,
+    url.pathname,
+    `${url.pathname}: canonical path does not match the page.`,
+  );
+  assert.ok(
+    document.querySelector('meta[name="description"]')?.content.trim(),
+    `${url.pathname}: missing meta description.`,
+  );
+  assert.ok(document.title.trim(), `${url.pathname}: missing page title.`);
+  assert.match(
+    document.querySelector('meta[name="robots"]')?.content ?? "",
+    /noindex/i,
+    `${url.pathname}: unconfigured preview builds must not be indexed.`,
+  );
   for (const anchor of document.querySelectorAll("a[href]")) {
     const href = new URL(anchor.getAttribute("href"), url);
     if (href.origin !== origin) continue;
@@ -71,7 +85,11 @@ for (const file of pages) {
     }
     if (info.isDirectory()) target = join(target, "index.html");
     await stat(target);
-    if (href.hash && target.endsWith(".html")) {
+    const checksStaticFragments =
+      url.pathname.startsWith("/docs/") ||
+      url.pathname.startsWith("/components/") ||
+      ["/formats/", "/themes/"].includes(url.pathname);
+    if (href.hash && target.endsWith(".html") && checksStaticFragments) {
       assert.ok(
         (await readDocument(target)).getElementById(
           decodeURIComponent(href.hash.slice(1)),
@@ -87,6 +105,34 @@ for (const file of pages) {
     `${dirname(file)} must have one page heading.`,
   );
 }
+
+const publicUrls = pages
+  .map(
+    (file) =>
+      new URL(
+        file
+          .slice(output.length)
+          .split(sep)
+          .join("/")
+          .replace(/index\.html$/, ""),
+        origin,
+      ).pathname,
+  )
+  .sort();
+const sitemap = await readFile(join(output, "sitemap.xml"), "utf8");
+const sitemapUrls = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)]
+  .map(([, value]) => new URL(value).pathname)
+  .sort();
+assert.deepEqual(
+  sitemapUrls,
+  publicUrls,
+  "The sitemap must list every public static page exactly once.",
+);
+assert.doesNotMatch(sitemap, /\/(generated|r)\//);
+
+const robots = await readFile(join(output, "robots.txt"), "utf8");
+assert.match(robots, /Disallow: \/(?:\r?\n|$)/);
+assert.match(robots, /Sitemap: .*\/sitemap\.xml/);
 console.log(
-  `Verified ${pages.length} documentation pages and ${linkCount} local links, including anchors.`,
+  `Verified ${pages.length} public pages, SEO metadata and ${linkCount} local links, including anchors.`,
 );


### PR DESCRIPTION
## Summary
- document the single-source template contribution, review, licensing, compatibility, and versioning workflow
- add canonical metadata, a complete sitemap, and explicit non-indexable preview behavior
- verify guide parity across search/navigation and static SEO/link output

## Verification
- pnpm exec vitest run tooling/docs/source-reference.test.ts (4 tests)
- pnpm validate (17 files, 62 tests)
- pnpm build (48 static routes)
- pnpm verify:docs (44 public pages, 2,555 links)
- git diff --check

## Boundaries
- no PDF suite: S03 is documentation/static metadata only, as specified
- no hosting, public URL, publication, deployment, dependency, or license decision

Closes #16