### PR TITLE
docs(implementation): record L12 merge

### DIFF
--- a/docs/implementation/lots/L12-documentation.md
+++ b/docs/implementation/lots/L12-documentation.md
@@ -1,6 +1,6 @@
 # L12 — Documentation, components, formats, and themes
 
-Status: **in review** in PR #40. Final branch: `docs/l12-contribution-seo`, based on `dev` commit `8cdf4837cf36f3134b236b1ad843cc17daf1db0e`. The maintainer authorized PR #31's merge and L12 implementation on 2026-08-31, then authorized validation and merge of subsequent pull requests on 2026-09-01.
+Status: **merged** through PR #40 at `8491f7d2a15364a3cdd4d376da08096c03896f40`. Final branch: `docs/l12-contribution-seo`, based on `dev` commit `8cdf4837cf36f3134b236b1ad843cc17daf1db0e`. The maintainer authorized PR #31's merge and L12 implementation on 2026-08-31, then authorized validation and merge of subsequent pull requests on 2026-09-01.
 
 Dependencies: L11. Requirements: FR-02, FR-13, FR-15, FR-16, FR-17.
 

--- a/docs/implementation/status.json
+++ b/docs/implementation/status.json
@@ -299,7 +299,7 @@
     {
       "id": "L12",
       "file": "lots/L12-documentation.md",
-      "state": "in_review",
+      "state": "merged",
       "dependsOn": ["L11"],
       "branch": "docs/l12-contribution-seo",
       "baseCommit": "8cdf4837cf36f3134b236b1ad843cc17daf1db0e",
@@ -333,10 +333,13 @@
         "6b84c374305eef7daf5d145c60eea6cf60a20215",
         "dce3332f9442c1d75e026cdf4ef628e0a0bad69f",
         "6cfdc872a8d0ab98c1ea3d75c96ea3fddca2acb5",
-        "ed900469b6843e05a7276ed3da97aac40d6a00a3"
+        "ed900469b6843e05a7276ed3da97aac40d6a00a3",
+        "1cd9b873d46705514a61df91388f286d8990b0f0"
       ],
       "evidence": "../qa/L12.md",
-      "blocker": null
+      "blocker": null,
+      "mergeCommit": "8491f7d2a15364a3cdd4d376da08096c03896f40",
+      "mergedAt": "2026-09-01T18:25:48Z"
     },
     {
       "id": "L13",

--- a/docs/qa/L12.md
+++ b/docs/qa/L12.md
@@ -499,3 +499,5 @@ The first static build exposed Next.js export's requirement that metadata routes
 The Codex runtime initially resolved pnpm 11.19.0 inside nested scripts although the repository requires 11.24.0. A temporary Corepack shim outside the repository made every recorded command use pnpm 11.24.0; no global installation or project file was changed. The known PDF.js standard-font warnings during template preview generation remain non-fatal and unchanged.
 
 No PDF suite was run because S03 changes documentation and static metadata only, as required by the lot. No host, license, public URL, publication or deployment was selected. The loopback canonical origin in local artifacts is deliberately non-indexable and is not a production claim.
+
+PR #40 passed all seven required remote contexts and merged into `dev` at `8491f7d2a15364a3cdd4d376da08096c03896f40` on 2026-09-01T18:25:48Z. Issue #16 closed from the observed merge and its Project item moved to Done. L12 is **merged**, not released; no deployment or publication occurred.


### PR DESCRIPTION
## Summary
- record the observed PR #40 merge commit and timestamp
- mark L12 merged in the lot status and QA evidence
- retain the distinction between merged and released

## Verification
- documentation-only tracking update
- git diff --check

Refs #16