### PR TITLE
docs(onboarding): clarify shadcn-first PDF setup

### DIFF
--- a/apps/www/src/app/(site)/docs/getting-started/page.tsx
+++ b/apps/www/src/app/(site)/docs/getting-started/page.tsx
@@ -1,12 +1,12 @@
 import Link from "next/link";
-import { DocsArticle } from "@/features/docs/docs-article";
+import { CodeBlock, DocsArticle } from "@/features/docs/docs-article";
 import { DocumentationShell } from "@/features/docs/documentation-shell";
 import { createPageMetadata } from "@/lib/site-metadata";
 
 export const metadata = createPageMetadata({
   title: "Getting started — docn-ui",
   description:
-    "Choose a template, install its source and render independently with local assets.",
+    "Add docn-ui PDF source to an existing shadcn project and render the first local document.",
   path: "/docs/getting-started/",
 });
 
@@ -14,67 +14,151 @@ export default function GettingStartedPage() {
   return (
     <DocumentationShell
       sections={[
-        { title: "What is ready", href: "#ready-foundations" },
-        { title: "Your first document", href: "#first-document" },
+        { title: "Before you begin", href: "#before-you-begin" },
+        { title: "Add the PDF layer", href: "#add-pdf-layer" },
+        { title: "Your first PDF", href: "#first-pdf" },
+        { title: "Theme boundaries", href: "#theme-boundaries" },
+        { title: "Choose what follows", href: "#next-steps" },
       ]}
     >
       <DocsArticle
         title="Getting started"
         breadcrumb="Getting started"
-        description="Start with your existing shadcn project. PDF source lives in your codebase, without a separate initializer or a hosted rendering service."
+        description="Start inside the shadcn project you already use. Add only the PDF source you need, render locally and keep ownership of every installed file."
       >
-        <section aria-labelledby="ready-foundations">
+        <section aria-labelledby="before-you-begin">
           <h2
-            id="ready-foundations"
-            className="text-xl font-semibold tracking-tight"
+            id="before-you-begin"
+            className="text-xl font-semibold tracking-tight text-balance"
           >
-            What is ready
+            Before you begin
           </h2>
-          <p className="mt-4 text-muted-foreground">
-            Seventeen templates cover invoices, receipts, resumes, reports,
-            badges and business cards. The catalog shows actual PDF-derived
-            previews and the relevant source files. Edit data, fonts and layouts
-            in your code; there is no template customization form to configure
-            first.
-          </p>
-          <p className="mt-4 text-muted-foreground">
-            Complete template installation is qualified through the official
-            shadcn CLI. Individual component detail pages and component-sized
-            installation are being built in L12. Development registry paths are
-            mutable; no immutable public release is available yet.
-          </p>
+          <div className="mt-4 space-y-4 text-muted-foreground">
+            <p>
+              This path assumes a React and TypeScript application with shadcn
+              already initialized. The quickest check is a working{" "}
+              <code>components.json</code> at the application root and at least
+              one shadcn component you can import.
+            </p>
+            <p>
+              If that file does not exist, initialize shadcn for your framework
+              first. Return here when its own component installation works;
+              docn-ui does not replace or repeat that setup.
+            </p>
+          </div>
+          <ExternalGuideLink href="https://ui.shadcn.com/docs/installation">
+            Initialize shadcn in your framework
+          </ExternalGuideLink>
         </section>
-        <section aria-labelledby="first-document">
+        <section aria-labelledby="add-pdf-layer">
           <h2
-            id="first-document"
-            className="text-xl font-semibold tracking-tight"
+            id="add-pdf-layer"
+            className="text-xl font-semibold tracking-tight text-balance"
           >
-            Your first document
+            Add the PDF layer, not another app
           </h2>
-          <ol className="mt-4 list-decimal space-y-4 pl-5">
+          <p className="mt-4 text-muted-foreground">
+            docn-ui is distributed through the official shadcn CLI. The CLI
+            reads your existing components.json, resolves the selected registry
+            item and writes its source into a separate docn directory. It does
+            not overwrite components/ui or introduce a second configuration.
+          </p>
+          <div className="mt-4">
+            <CodeBlock label="The installation model" highlight={false}>
+              {
+                "your shadcn project\n  + one docn-ui registry item\n  + verified local PDF assets\n  = source-owned PDF rendering in the same application"
+              }
+            </CodeBlock>
+          </div>
+          <p className="mt-4 text-muted-foreground">
+            The current registry is a mutable development registry. Use the
+            exact local setup in the installation guide until an immutable
+            public namespace is released.
+          </p>
+          <GuideLink href="/docs/installation/">
+            Connect the registry and install source
+          </GuideLink>
+        </section>
+        <section aria-labelledby="first-pdf">
+          <h2
+            id="first-pdf"
+            className="text-xl font-semibold tracking-tight text-balance"
+          >
+            Render your first PDF
+          </h2>
+          <ol className="mt-4 list-decimal space-y-4 pl-5 text-muted-foreground marker:text-foreground">
             <li>
-              <GuideLink href="/docs/installation/">Install source</GuideLink>{" "}
-              into the project that already holds your components.json.
+              Install the small text example or one template from the catalog
+              through the shadcn CLI.
             </li>
             <li>
               <GuideLink href="/docs/local-assets/">
                 Prepare local assets
               </GuideLink>{" "}
-              for browser or Node rendering.
+              on your own origin or Node filesystem.
             </li>
             <li>
               <GuideLink href="/docs/browser-and-node/">
-                Run the verified example
+                Run the verified browser or Node example
               </GuideLink>
-              , then replace its data with your own.
+              , confirm that a real PDF is produced, then replace its sample
+              data.
+            </li>
+            <li>
+              Commit the installed source and adapt it like any other shadcn
+              registry item.
+            </li>
+          </ol>
+        </section>
+        <section aria-labelledby="theme-boundaries">
+          <h2
+            id="theme-boundaries"
+            className="text-xl font-semibold tracking-tight text-balance"
+          >
+            Keep site and paper themes separate
+          </h2>
+          <p className="mt-4 text-muted-foreground">
+            Your site may use shadcn CSS variables, Tailwind classes, dark mode
+            and web fonts. The PDF renderer uses explicit print-safe roles for
+            paper, text, muted text, accent, borders, spacing and registered
+            fonts. Nothing is inherited automatically.
+          </p>
+          <p className="mt-4 text-muted-foreground">
+            Map only deliberate choices such as a qualified brand accent. A
+            white site foreground is not a valid default for text printed on
+            white paper.
+          </p>
+          <GuideLink href="/docs/themes/">
+            Map your design system deliberately
+          </GuideLink>
+        </section>
+        <section aria-labelledby="next-steps">
+          <h2
+            id="next-steps"
+            className="text-xl font-semibold tracking-tight text-balance"
+          >
+            Choose what follows
+          </h2>
+          <ul className="mt-4 list-disc space-y-3 pl-5 text-muted-foreground marker:text-foreground">
+            <li>
+              <GuideLink href="/templates/">Choose a composition</GuideLink>{" "}
+              when you want a complete document.
+            </li>
+            <li>
+              <GuideLink href="/components/">Choose PDF components</GuideLink>{" "}
+              when you want to compose your own layout.
+            </li>
+            <li>
+              <GuideLink href="/formats/">Review physical formats</GuideLink>{" "}
+              before changing dimensions or printing.
             </li>
             <li>
               <GuideLink href="/docs/limitations/">
-                Review the limitations
+                Review qualified boundaries
               </GuideLink>{" "}
-              and inspect an actual-size print before production use.
+              before production use.
             </li>
-          </ol>
+          </ul>
         </section>
       </DocsArticle>
     </DocumentationShell>
@@ -85,9 +169,28 @@ function GuideLink({ href, children }: { href: string; children: string }) {
   return (
     <Link
       href={href}
-      className="font-medium underline underline-offset-4 outline-none focus-visible:rounded-sm focus-visible:ring-3 focus-visible:ring-ring/50"
+      className="font-medium text-foreground underline underline-offset-4 outline-none focus-visible:rounded-sm focus-visible:ring-3 focus-visible:ring-ring/50"
     >
       {children}
     </Link>
+  );
+}
+
+function ExternalGuideLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: string;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="mt-3 inline-flex min-h-10 items-center font-medium underline underline-offset-4 outline-none focus-visible:rounded-sm focus-visible:ring-3 focus-visible:ring-ring/50"
+    >
+      {children}
+    </a>
   );
 }

--- a/apps/www/src/app/(site)/docs/page.tsx
+++ b/apps/www/src/app/(site)/docs/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { DocsArticle } from "@/features/docs/docs-article";
+import { CodeBlock, DocsArticle } from "@/features/docs/docs-article";
 import { DocumentationShell } from "@/features/docs/documentation-shell";
 import { guideIndex } from "@/content/docs/guide-index";
 import { createPageMetadata } from "@/lib/site-metadata";
@@ -13,11 +13,83 @@ export const metadata = createPageMetadata({
 
 export default function DocsPage() {
   return (
-    <DocumentationShell>
+    <DocumentationShell
+      sections={[
+        { title: "The PDF layer", href: "#pdf-layer" },
+        { title: "How it fits", href: "#how-it-fits" },
+        { title: "Start here", href: "#start-here" },
+        { title: "Guides", href: "#available-guides" },
+      ]}
+    >
       <DocsArticle
-        title="Documentation"
-        description="Extend your shadcn project to PDF. Install the source, prepare local assets, then build documents in your own codebase."
+        title="Extend shadcn to PDF"
+        description="docn-ui adds printable document source to the shadcn workflow you already use. Keep your project, your components.json and your ownership of the code."
       >
+        <section aria-labelledby="pdf-layer">
+          <h2
+            id="pdf-layer"
+            className="text-xl font-semibold tracking-tight text-balance"
+          >
+            The missing PDF layer
+          </h2>
+          <div className="mt-4 space-y-4 text-muted-foreground">
+            <p>
+              shadcn installs interface source into your application. docn-ui
+              uses the same registry and CLI model for PDF components, templates
+              and rendering helpers. It is not a hosted editor, a second project
+              initializer or a parallel UI kit.
+            </p>
+            <p>
+              Your existing shadcn setup remains authoritative. docn-ui adds a
+              separate <code>docn/</code> source tree because PDF primitives run
+              in a document renderer rather than the browser DOM.
+            </p>
+          </div>
+        </section>
+        <section aria-labelledby="how-it-fits">
+          <h2
+            id="how-it-fits"
+            className="text-xl font-semibold tracking-tight text-balance"
+          >
+            How it fits your project
+          </h2>
+          <CodeBlock label="Your existing application" highlight={false}>
+            {
+              "components.json       # your existing shadcn configuration\ncomponents/ui/       # your existing interface components\ndocn/                # installed PDF source\n  components/        # PDF-only primitives\n  templates/         # the compositions you choose\npublic/generated/    # verified local PDF assets"
+            }
+          </CodeBlock>
+          <p className="mt-4 text-muted-foreground">
+            Site and document themes are intentionally separate. You may map a
+            brand accent or spacing decision into a PDF theme, but browser dark
+            mode never turns printable text white or paper black.
+          </p>
+          <Link
+            href="/docs/themes/"
+            className="mt-3 inline-flex min-h-10 items-center font-medium underline underline-offset-4 outline-none focus-visible:rounded-sm focus-visible:ring-3 focus-visible:ring-ring/50"
+          >
+            Understand shadcn and PDF theme mapping
+          </Link>
+        </section>
+        <section aria-labelledby="start-here">
+          <h2
+            id="start-here"
+            className="text-xl font-semibold tracking-tight text-balance"
+          >
+            Start from the project you have
+          </h2>
+          <ol className="mt-4 list-decimal space-y-3 pl-5 text-muted-foreground marker:text-foreground">
+            <li>Confirm that the application has a working components.json.</li>
+            <li>Add one docn-ui item with the official shadcn CLI.</li>
+            <li>Prepare the verified fonts and assets used by that item.</li>
+            <li>Render one local PDF, then edit the source you now own.</li>
+          </ol>
+          <Link
+            href="/docs/getting-started/"
+            className="mt-4 inline-flex min-h-10 items-center font-medium underline underline-offset-4 outline-none focus-visible:rounded-sm focus-visible:ring-3 focus-visible:ring-ring/50"
+          >
+            Follow the shadcn-first quick start
+          </Link>
+        </section>
         <section aria-labelledby="available-guides">
           <h2
             id="available-guides"

--- a/apps/www/src/content/docs/guide-content.ts
+++ b/apps/www/src/content/docs/guide-content.ts
@@ -23,19 +23,30 @@ export const guideContent: Record<GuideSlug, readonly GuideSection[]> = {
   installation: [
     {
       id: "prerequisites",
-      title: "Keep your existing project",
+      title: "Start from a working shadcn project",
       blocks: [
         {
           type: "paragraph",
-          text: "Start with a React 19 TypeScript project that already has a working shadcn components.json. Keep its style, aliases and UI components. docn-ui adds source under a separate root-level docn directory; it does not reinitialize shadcn or require a docn runtime package.",
+          text: "docn-ui extends an existing React and TypeScript shadcn project. Confirm that components.json exists and that the official CLI can add a normal shadcn component before installing PDF source. Keep the project's selected base, style, aliases, Tailwind setup and components/ui directory.",
+        },
+        {
+          type: "link",
+          text: "Initialize shadcn first if your project is not ready",
+          href: "https://ui.shadcn.com/docs/installation",
         },
         {
           type: "paragraph",
-          text: "Qualification currently uses Node 24.18.0, pnpm 11.24.0, shadcn 4.19.0 and React 19.2.8. Other combinations are not guaranteed. Internal docn imports are relative, so a consumer using a different source alias does not need to adopt @/*.",
+          text: "docn-ui does not run a second initializer. The official shadcn CLI reads the same components.json and installs PDF-only source under a separate root-level docn directory. Internal docn imports are relative, so a consumer using a different source alias does not need to adopt @/*.",
         },
+      ],
+    },
+    {
+      id: "development-registry",
+      title: "Serve the development registry",
+      blocks: [
         {
           type: "paragraph",
-          text: "The registry is a local development registry, not an immutable public release. To serve your own checkout, run the following commands in the docn-ui repository. The preview defaults to port 4173. Leave it running while installing from a second terminal in your consumer project.",
+          text: "No immutable public namespace is released yet. For the qualified development flow, serve a docn-ui checkout locally and leave it running while the shadcn CLI installs from a second terminal in your application. Qualification currently uses Node 24.18.0, pnpm 11.24.0, shadcn 4.19.0 and React 19.2.8.",
         },
         {
           type: "code",
@@ -47,26 +58,26 @@ export const guideContent: Record<GuideSlug, readonly GuideSection[]> = {
     },
     {
       id: "install-source",
-      title: "Install the source",
+      title: "Add PDF source with the shadcn CLI",
       blocks: [
         {
           type: "paragraph",
-          text: "Run this command from your consumer project. It uses the configured registry build URL, which defaults to port 4173 even if you view this documentation on another port. To host the registry elsewhere, set DOCN_REGISTRY_ORIGIN to its full /r/dev/ URL before building and serve it there. Install the composed component example while the template catalog is rebuilt.",
+          text: "Run the command from the application that owns components.json. Start with the small text example to verify installation and rendering before choosing a full template. The URL defaults to the local registry on port 4173; set DOCN_REGISTRY_ORIGIN to another complete /r/dev/ origin before building only when you deliberately host that development registry elsewhere.",
         },
-        { type: "install", item: "docn-component-example" },
+        { type: "install", item: "docn-text-example" },
         {
           type: "paragraph",
-          text: "Your existing components.json remains authoritative. Do not replace it with docn-ui's own site configuration. A future public @docn namespace will be an additional registries entry, not a second initializer. No public namespace or release URL is promised today.",
+          text: "Inspect the files written under docn/ and commit them like any shadcn registry source. Your existing components.json remains authoritative; do not replace it with docn-ui's site configuration. A future public @docn namespace will be an additional registry entry, not another project initializer.",
         },
       ],
     },
     {
       id: "prepare-assets",
-      title: "Prepare assets, then render",
+      title: "Prepare assets and verify one PDF",
       blocks: [
         {
           type: "paragraph",
-          text: "Source installation does not silently download binary fonts. Review the visible asset installer and run the appropriate browser or Node command before rendering. Missing assets are an error, not a reason to silently substitute a font.",
+          text: "Source installation does not silently download binary fonts. Review the asset manifest and run the browser or Node installer from your application. Then render the verified example once before replacing its data or composing a larger document. Missing assets are an error, not a reason to silently substitute a font.",
         },
         {
           type: "link",

--- a/apps/www/src/content/docs/guide-index.ts
+++ b/apps/www/src/content/docs/guide-index.ts
@@ -3,7 +3,7 @@ export const guideIndex = [
     slug: "installation",
     title: "Installation",
     description:
-      "Add PDF source to your existing shadcn project without changing its configuration.",
+      "Add the PDF layer to an existing shadcn project through the CLI and configuration you already use.",
   },
   {
     slug: "local-assets",

--- a/apps/www/src/features/docs/page-index.ts
+++ b/apps/www/src/features/docs/page-index.ts
@@ -53,13 +53,13 @@ export const knownPages: readonly KnownPage[] = [
   },
   {
     title: "Documentation",
-    description: "Available docn-ui guides",
+    description: "How docn-ui extends an existing shadcn project to PDF",
     href: "/docs/",
     section: "Documentation",
   },
   {
     title: "Getting started",
-    description: "Current capabilities and project boundaries",
+    description: "Add PDF source through shadcn and render the first document",
     href: "/docs/getting-started/",
     section: "Documentation",
   },


### PR DESCRIPTION
## Summary
- reposition the documentation overview around docn-ui as the PDF layer for an existing shadcn project
- rebuild Getting Started around prerequisites, registry installation, the first local PDF, explicit theme boundaries, and task-based next steps
- restructure Installation into shadcn readiness, development registry, official CLI installation, assets, and verification
- align search descriptions with the new onboarding flow

## Reference patterns
- official shadcn installation and registry guidance: existing project configuration, source ownership, CLI add flow
- official Tailwind framework guides: environment prerequisites followed by a short verifiable setup

## Verification
- browser inspection of Overview, Getting Started, and Installation
- pnpm validate (17 files, 62 tests)
- pnpm build (48 static routes)
- pnpm verify:docs (44 public pages, 2,568 local links)
- git diff --check

## Notes
- one pre-validation run hit the existing 10-second source-reference timeout; its isolated rerun passed 4/4 and the complete validation rerun passed 62/62
- no dependency, PDF source, hosting, publication, or release change