### PR TITLE
docs(onboarding): streamline the first PDF workflow

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -29,7 +29,7 @@
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.5",
     "cross-env": "10.1.0",
-    "shadcn": "4.19.0",
+    "shadcn": "4.19.1",
     "tailwindcss": "4.3.3",
     "tw-animate-css": "1.4.0"
   }

--- a/apps/www/src/app/(site)/docs/getting-started/page.tsx
+++ b/apps/www/src/app/(site)/docs/getting-started/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { CodeBlock, DocsArticle } from "@/features/docs/docs-article";
+import { DocsArticle } from "@/features/docs/docs-article";
 import { DocumentationShell } from "@/features/docs/documentation-shell";
 import { createPageMetadata } from "@/lib/site-metadata";
 
@@ -14,130 +14,66 @@ export default function GettingStartedPage() {
   return (
     <DocumentationShell
       sections={[
-        { title: "Before you begin", href: "#before-you-begin" },
-        { title: "Add the PDF layer", href: "#add-pdf-layer" },
-        { title: "Your first PDF", href: "#first-pdf" },
-        { title: "Theme boundaries", href: "#theme-boundaries" },
-        { title: "Choose what follows", href: "#next-steps" },
+        { title: "Requirements", href: "#requirements" },
+        { title: "Install and render", href: "#install-and-render" },
+        { title: "Next steps", href: "#next-steps" },
       ]}
     >
       <DocsArticle
         title="Getting started"
         breadcrumb="Getting started"
-        description="Start inside the shadcn project you already use. Add only the PDF source you need, render locally and keep ownership of every installed file."
+        description="Install one PDF document in an existing shadcn project and render it locally."
       >
-        <section aria-labelledby="before-you-begin">
+        <section aria-labelledby="requirements">
           <h2
-            id="before-you-begin"
+            id="requirements"
             className="text-xl font-semibold tracking-tight text-balance"
           >
-            Before you begin
+            Requirements
           </h2>
-          <div className="mt-4 space-y-4 text-muted-foreground">
-            <p>
-              This path assumes a React and TypeScript application with shadcn
-              already initialized. The quickest check is a working{" "}
-              <code>components.json</code> at the application root and at least
-              one shadcn component you can import.
-            </p>
-            <p>
-              If that file does not exist, initialize shadcn for your framework
-              first. Return here when its own component installation works;
-              docn-ui does not replace or repeat that setup.
-            </p>
-          </div>
+          <p className="mt-4 text-muted-foreground">
+            Use a React and TypeScript project with shadcn initialized and a
+            working <code>components.json</code>. If you do not have one, finish
+            the official framework setup first.
+          </p>
           <ExternalGuideLink href="https://ui.shadcn.com/docs/installation">
-            Initialize shadcn in your framework
+            Set up shadcn
           </ExternalGuideLink>
         </section>
-        <section aria-labelledby="add-pdf-layer">
+        <section aria-labelledby="install-and-render">
           <h2
-            id="add-pdf-layer"
+            id="install-and-render"
             className="text-xl font-semibold tracking-tight text-balance"
           >
-            Add the PDF layer, not another app
-          </h2>
-          <p className="mt-4 text-muted-foreground">
-            docn-ui is distributed through the official shadcn CLI. The CLI
-            reads your existing components.json, resolves the selected registry
-            item and writes its source into a separate docn directory. It does
-            not overwrite components/ui or introduce a second configuration.
-          </p>
-          <div className="mt-4">
-            <CodeBlock label="The installation model" highlight={false}>
-              {
-                "your shadcn project\n  + one docn-ui registry item\n  + verified local PDF assets\n  = source-owned PDF rendering in the same application"
-              }
-            </CodeBlock>
-          </div>
-          <p className="mt-4 text-muted-foreground">
-            The current registry is a mutable development registry. Use the
-            exact local setup in the installation guide until an immutable
-            public namespace is released.
-          </p>
-          <GuideLink href="/docs/installation/">
-            Connect the registry and install source
-          </GuideLink>
-        </section>
-        <section aria-labelledby="first-pdf">
-          <h2
-            id="first-pdf"
-            className="text-xl font-semibold tracking-tight text-balance"
-          >
-            Render your first PDF
+            Install and render
           </h2>
           <ol className="mt-4 list-decimal space-y-4 pl-5 text-muted-foreground marker:text-foreground">
             <li>
-              Install the small text example or one template from the catalog
-              through the shadcn CLI.
+              <GuideLink href="/docs/installation/">
+                Install the text example
+              </GuideLink>{" "}
+              with the official shadcn CLI.
             </li>
             <li>
               <GuideLink href="/docs/local-assets/">
                 Prepare local assets
-              </GuideLink>{" "}
-              on your own origin or Node filesystem.
+              </GuideLink>
+              .
             </li>
             <li>
               <GuideLink href="/docs/browser-and-node/">
-                Run the verified browser or Node example
+                Render the browser or Node example
               </GuideLink>
-              , confirm that a real PDF is produced, then replace its sample
-              data.
-            </li>
-            <li>
-              Commit the installed source and adapt it like any other shadcn
-              registry item.
+              , then edit the installed source and sample data.
             </li>
           </ol>
-        </section>
-        <section aria-labelledby="theme-boundaries">
-          <h2
-            id="theme-boundaries"
-            className="text-xl font-semibold tracking-tight text-balance"
-          >
-            Keep site and paper themes separate
-          </h2>
-          <p className="mt-4 text-muted-foreground">
-            Your site may use shadcn CSS variables, Tailwind classes, dark mode
-            and web fonts. The PDF renderer uses explicit print-safe roles for
-            paper, text, muted text, accent, borders, spacing and registered
-            fonts. Nothing is inherited automatically.
-          </p>
-          <p className="mt-4 text-muted-foreground">
-            Map only deliberate choices such as a qualified brand accent. A
-            white site foreground is not a valid default for text printed on
-            white paper.
-          </p>
-          <GuideLink href="/docs/themes/">
-            Map your design system deliberately
-          </GuideLink>
         </section>
         <section aria-labelledby="next-steps">
           <h2
             id="next-steps"
             className="text-xl font-semibold tracking-tight text-balance"
           >
-            Choose what follows
+            Next steps
           </h2>
           <ul className="mt-4 list-disc space-y-3 pl-5 text-muted-foreground marker:text-foreground">
             <li>
@@ -149,14 +85,9 @@ export default function GettingStartedPage() {
               when you want to compose your own layout.
             </li>
             <li>
-              <GuideLink href="/formats/">Review physical formats</GuideLink>{" "}
-              before changing dimensions or printing.
-            </li>
-            <li>
-              <GuideLink href="/docs/limitations/">
-                Review qualified boundaries
-              </GuideLink>{" "}
-              before production use.
+              <GuideLink href="/docs/themes/">Map document themes</GuideLink>{" "}
+              when you want to reuse selected brand decisions without inheriting
+              the site theme.
             </li>
           </ul>
         </section>

--- a/apps/www/src/app/(site)/docs/page.tsx
+++ b/apps/www/src/app/(site)/docs/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { CodeBlock, DocsArticle } from "@/features/docs/docs-article";
+import { DocsArticle } from "@/features/docs/docs-article";
 import { DocumentationShell } from "@/features/docs/documentation-shell";
 import { guideIndex } from "@/content/docs/guide-index";
 import { createPageMetadata } from "@/lib/site-metadata";
@@ -15,8 +15,7 @@ export default function DocsPage() {
   return (
     <DocumentationShell
       sections={[
-        { title: "The PDF layer", href: "#pdf-layer" },
-        { title: "How it fits", href: "#how-it-fits" },
+        { title: "What docn-ui adds", href: "#what-docn-adds" },
         { title: "Start here", href: "#start-here" },
         { title: "Guides", href: "#available-guides" },
       ]}
@@ -25,49 +24,31 @@ export default function DocsPage() {
         title="Extend shadcn to PDF"
         description="docn-ui adds printable document source to the shadcn workflow you already use. Keep your project, your components.json and your ownership of the code."
       >
-        <section aria-labelledby="pdf-layer">
+        <section aria-labelledby="what-docn-adds">
           <h2
-            id="pdf-layer"
+            id="what-docn-adds"
             className="text-xl font-semibold tracking-tight text-balance"
           >
-            The missing PDF layer
+            What docn-ui adds
           </h2>
           <div className="mt-4 space-y-4 text-muted-foreground">
             <p>
-              shadcn installs interface source into your application. docn-ui
-              uses the same registry and CLI model for PDF components, templates
-              and rendering helpers. It is not a hosted editor, a second project
-              initializer or a parallel UI kit.
+              Install PDF components and templates with the official shadcn CLI,
+              then edit the source in your application. Your existing
+              <code> components.json</code>, aliases and UI components stay in
+              place.
             </p>
             <p>
-              Your existing shadcn setup remains authoritative. docn-ui adds a
-              separate <code>docn/</code> source tree because PDF primitives run
-              in a document renderer rather than the browser DOM.
+              Installed document source lives under <code>docn/</code>. It uses
+              PDF primitives and print-safe tokens rather than browser DOM,
+              Tailwind classes or automatic site-theme inheritance.
             </p>
           </div>
-        </section>
-        <section aria-labelledby="how-it-fits">
-          <h2
-            id="how-it-fits"
-            className="text-xl font-semibold tracking-tight text-balance"
-          >
-            How it fits your project
-          </h2>
-          <CodeBlock label="Your existing application" highlight={false}>
-            {
-              "components.json       # your existing shadcn configuration\ncomponents/ui/       # your existing interface components\ndocn/                # installed PDF source\n  components/        # PDF-only primitives\n  templates/         # the compositions you choose\npublic/generated/    # verified local PDF assets"
-            }
-          </CodeBlock>
-          <p className="mt-4 text-muted-foreground">
-            Site and document themes are intentionally separate. You may map a
-            brand accent or spacing decision into a PDF theme, but browser dark
-            mode never turns printable text white or paper black.
-          </p>
           <Link
             href="/docs/themes/"
             className="mt-3 inline-flex min-h-10 items-center font-medium underline underline-offset-4 outline-none focus-visible:rounded-sm focus-visible:ring-3 focus-visible:ring-ring/50"
           >
-            Understand shadcn and PDF theme mapping
+            Understand document themes
           </Link>
         </section>
         <section aria-labelledby="start-here">
@@ -78,10 +59,9 @@ export default function DocsPage() {
             Start from the project you have
           </h2>
           <ol className="mt-4 list-decimal space-y-3 pl-5 text-muted-foreground marker:text-foreground">
-            <li>Confirm that the application has a working components.json.</li>
-            <li>Add one docn-ui item with the official shadcn CLI.</li>
-            <li>Prepare the verified fonts and assets used by that item.</li>
-            <li>Render one local PDF, then edit the source you now own.</li>
+            <li>Start from a working shadcn React project.</li>
+            <li>Install one document with the shadcn CLI.</li>
+            <li>Prepare its assets and render the PDF locally.</li>
           </ol>
           <Link
             href="/docs/getting-started/"

--- a/apps/www/src/content/docs/guide-content.ts
+++ b/apps/www/src/content/docs/guide-content.ts
@@ -27,16 +27,12 @@ export const guideContent: Record<GuideSlug, readonly GuideSection[]> = {
       blocks: [
         {
           type: "paragraph",
-          text: "docn-ui extends an existing React and TypeScript shadcn project. Confirm that components.json exists and that the official CLI can add a normal shadcn component before installing PDF source. Keep the project's selected base, style, aliases, Tailwind setup and components/ui directory.",
+          text: "Use an existing React and TypeScript project with shadcn initialized and a working components.json. docn-ui keeps its selected base, style, aliases, Tailwind setup and components/ui directory unchanged.",
         },
         {
           type: "link",
-          text: "Initialize shadcn first if your project is not ready",
+          text: "Set up shadcn first",
           href: "https://ui.shadcn.com/docs/installation",
-        },
-        {
-          type: "paragraph",
-          text: "docn-ui does not run a second initializer. The official shadcn CLI reads the same components.json and installs PDF-only source under a separate root-level docn directory. Internal docn imports are relative, so a consumer using a different source alias does not need to adopt @/*.",
         },
       ],
     },
@@ -46,7 +42,7 @@ export const guideContent: Record<GuideSlug, readonly GuideSection[]> = {
       blocks: [
         {
           type: "paragraph",
-          text: "No immutable public namespace is released yet. For the qualified development flow, serve a docn-ui checkout locally and leave it running while the shadcn CLI installs from a second terminal in your application. Qualification currently uses Node 24.18.0, pnpm 11.24.0, shadcn 4.19.0 and React 19.2.8.",
+          text: "Until the public namespace is released, serve a docn-ui checkout locally and leave it running while the shadcn CLI installs from a second terminal. This flow is qualified with Node 24.18.0, pnpm 11.24.0, shadcn 4.19.1 and React 19.2.8.",
         },
         {
           type: "code",
@@ -62,12 +58,12 @@ export const guideContent: Record<GuideSlug, readonly GuideSection[]> = {
       blocks: [
         {
           type: "paragraph",
-          text: "Run the command from the application that owns components.json. Start with the small text example to verify installation and rendering before choosing a full template. The URL defaults to the local registry on port 4173; set DOCN_REGISTRY_ORIGIN to another complete /r/dev/ origin before building only when you deliberately host that development registry elsewhere.",
+          text: "Run the command from the application that owns components.json. Start with the text example before choosing a full template. The URL defaults to the local registry on port 4173; set DOCN_REGISTRY_ORIGIN before building only when the development registry uses another complete /r/dev/ origin.",
         },
         { type: "install", item: "docn-text-example" },
         {
           type: "paragraph",
-          text: "Inspect the files written under docn/ and commit them like any shadcn registry source. Your existing components.json remains authoritative; do not replace it with docn-ui's site configuration. A future public @docn namespace will be an additional registry entry, not another project initializer.",
+          text: "Inspect and commit the files written under docn/. Your existing components.json remains authoritative.",
         },
       ],
     },
@@ -77,7 +73,7 @@ export const guideContent: Record<GuideSlug, readonly GuideSection[]> = {
       blocks: [
         {
           type: "paragraph",
-          text: "Source installation does not silently download binary fonts. Review the asset manifest and run the browser or Node installer from your application. Then render the verified example once before replacing its data or composing a larger document. Missing assets are an error, not a reason to silently substitute a font.",
+          text: "Review the asset manifest and run the browser or Node installer from your application. Then render the example once before replacing its data or composing a larger document. Missing assets produce an error instead of a silent font substitution.",
         },
         {
           type: "link",

--- a/apps/www/src/features/catalog/template-catalog.tsx
+++ b/apps/www/src/features/catalog/template-catalog.tsx
@@ -33,7 +33,7 @@ function TemplateActions({ template }: { template: TemplateCatalogEntry }) {
     () => window.location.origin,
     () => "http://127.0.0.1:4173",
   );
-  const installCommand = `corepack pnpm dlx shadcn@4.19.0 add ${origin}/r/dev/docn-${template.id}.json`;
+  const installCommand = `corepack pnpm dlx shadcn@4.19.1 add ${origin}/r/dev/docn-${template.id}.json`;
 
   async function copyInstallCommand() {
     const success = await copyText(installCommand).catch(() => false);

--- a/apps/www/src/features/docs/component-install.tsx
+++ b/apps/www/src/features/docs/component-install.tsx
@@ -19,7 +19,7 @@ export function ComponentInstall({
     () => "http://127.0.0.1:4173",
   );
   const command = (items: string[]) =>
-    `corepack pnpm dlx shadcn@4.19.0 add ${items.map((item) => `${origin}/r/dev/${item}.json`).join(" ")}`;
+    `corepack pnpm dlx shadcn@4.19.1 add ${items.map((item) => `${origin}/r/dev/${item}.json`).join(" ")}`;
   return (
     <div className="space-y-4">
       <p className="text-muted-foreground">

--- a/apps/www/src/features/docs/guide-article.tsx
+++ b/apps/www/src/features/docs/guide-article.tsx
@@ -30,7 +30,7 @@ function GuideContentBlock({ block }: { block: GuideBlock }) {
         <CodeBlock
           label="Install source"
           highlight={false}
-        >{`corepack pnpm dlx shadcn@4.19.0 add ${new URL(`${block.item}.json`, registryBase).href}`}</CodeBlock>
+        >{`corepack pnpm dlx shadcn@4.19.1 add ${new URL(`${block.item}.json`, registryBase).href}`}</CodeBlock>
       );
     case "assets":
       return (

--- a/apps/www/src/features/registry/registry-source-panel.tsx
+++ b/apps/www/src/features/registry/registry-source-panel.tsx
@@ -192,8 +192,8 @@ export function RegistrySourcePanel({
 
   const selectedFile =
     files.find((file) => file.target === selectedTarget) ?? files[0];
-  const installCommand = `corepack pnpm dlx shadcn@4.19.0 add ${origin}/r/dev/${itemName}.json`;
-  const assetCommand = `${currentSource?.assetsIncluded === false ? `corepack pnpm dlx shadcn@4.19.0 add ${origin}/r/dev/docn-fonts.json\n` : ""}node docn/assets/install.mjs --manifest ${origin}/r/dev/assets/manifest.json --target browser`;
+  const installCommand = `corepack pnpm dlx shadcn@4.19.1 add ${origin}/r/dev/${itemName}.json`;
+  const assetCommand = `${currentSource?.assetsIncluded === false ? `corepack pnpm dlx shadcn@4.19.1 add ${origin}/r/dev/docn-fonts.json\n` : ""}node docn/assets/install.mjs --manifest ${origin}/r/dev/assets/manifest.json --target browser`;
   const headingId = `registry-source-${itemName}`;
 
   return (

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -24,7 +24,7 @@ Sources: [Next static exports](https://nextjs.org/docs/app/guides/static-exports
 
 | Dependency | Version | License | Reason and browser impact |
 | --- | --- | --- | --- |
-| shadcn CLI / CSS helpers | 4.19.0 | MIT | Source generation and compile-time Tailwind helpers; dev dependency, no CLI JavaScript in browser |
+| shadcn CLI / CSS helpers | 4.19.1 | MIT | Source generation and compile-time Tailwind helpers; dev dependency, no CLI JavaScript in browser |
 | @base-ui/react | 1.7.0 | MIT | Button and Tooltip primitives; imported through component subpaths |
 | Tailwind CSS / PostCSS plugin | 4.3.3 | MIT | Build-time utility generation; emitted CSS only |
 | class-variance-authority | 0.7.1 | Apache-2.0 | Generated Button variants; small client utility |

--- a/docs/guides/REGISTRY_INSTALLATION.md
+++ b/docs/guides/REGISTRY_INSTALLATION.md
@@ -5,7 +5,7 @@ The L07 registry is available for local qualification. It is not a published rel
 ## Prerequisites
 
 - Node.js 24.x and pnpm 11.24.0 for the qualified development workflow.
-- A React 19 TypeScript project initialized with shadcn 4.19.0.
+- A React 19 TypeScript project initialized with shadcn 4.19.1.
 - An existing shadcn `components.json` file. Keep its current style, aliases, base, and registry entries; docn-ui does not require `@/*` or a second initialization. The official CLI resolves generated `~/docn/**` targets below the consumer project root, and those files use relative internal imports.
 - A running local docn-ui site. From this repository, `corepack pnpm dev` serves the registry at the origin printed by Next.js.
 
@@ -16,7 +16,7 @@ The registry items declare their exact React-pdf, pdf-lib, Zod, QR, and React de
 Open a template detail page and copy the command shown beside its source. With the default static preview origin, the minimal business card command is:
 
 ```sh
-corepack pnpm dlx shadcn@4.19.0 add http://127.0.0.1:4173/r/dev/docn-business-card-minimal.json
+corepack pnpm dlx shadcn@4.19.1 add http://127.0.0.1:4173/r/dev/docn-business-card-minimal.json
 ```
 
 The detail page reads the same generated item JSON used by the CLI. Its source viewer follows all registry dependencies and exposes every installed file, including the asset utility. Review those files before running the command.
@@ -56,9 +56,9 @@ The installed files belong to the consumer. Edit the template, primitives, theme
 Before updating, inspect the current registry item and the proposed difference:
 
 ```sh
-corepack pnpm dlx shadcn@4.19.0 view http://127.0.0.1:4173/r/dev/docn-business-card-minimal.json
-corepack pnpm dlx shadcn@4.19.0 add http://127.0.0.1:4173/r/dev/docn-business-card-minimal.json --dry-run
-corepack pnpm dlx shadcn@4.19.0 add http://127.0.0.1:4173/r/dev/docn-business-card-minimal.json --diff
+corepack pnpm dlx shadcn@4.19.1 view http://127.0.0.1:4173/r/dev/docn-business-card-minimal.json
+corepack pnpm dlx shadcn@4.19.1 add http://127.0.0.1:4173/r/dev/docn-business-card-minimal.json --dry-run
+corepack pnpm dlx shadcn@4.19.1 add http://127.0.0.1:4173/r/dev/docn-business-card-minimal.json --diff
 ```
 
 Do not add `--overwrite` to the documented workflow. Resolve source and asset differences explicitly. Immutable release URLs will make compatible updates deliberate; an incompatible source contract will use a new major path.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jsqr": "1.4.0",
     "pdfjs-dist": "6.2.108",
     "prettier": "3.9.6",
-    "shadcn": "4.19.0",
+    "shadcn": "4.19.1",
     "typescript": "5.9.3",
     "vitest": "4.1.11"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: 3.9.6
         version: 3.9.6
       shadcn:
-        specifier: 4.19.0
-        version: 4.19.0(supports-color@7.2.0)(typescript@5.9.3)
+        specifier: 4.19.1
+        version: 4.19.1(supports-color@7.2.0)(typescript@5.9.3)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -118,8 +118,8 @@ importers:
         specifier: 10.1.0
         version: 10.1.0
       shadcn:
-        specifier: 4.19.0
-        version: 4.19.0(supports-color@7.2.0)(typescript@5.9.3)
+        specifier: 4.19.1
+        version: 4.19.1(supports-color@7.2.0)(typescript@5.9.3)
       tailwindcss:
         specifier: 4.3.3
         version: 4.3.3
@@ -3777,8 +3777,8 @@ packages:
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
-  shadcn@4.19.0:
-    resolution: {integrity: sha512-EQF6R+CUXTsEP2BpyhxrUEAFesrtFD1POvVOf5jM+wkgtA4kG1EW1+1Wlmi9LqiprSL681JJXBcS0u8WkVVVyQ==}
+  shadcn@4.19.1:
+    resolution: {integrity: sha512-QZ++YvYniZCEZHxBenWUsZnzKCDSUKwRqi0io7ovS9Him02zrg1U8AJCRTL0PWOaEM46NpTlw8PwewWk+9rCng==}
     engines: {node: '>=20.18.1'}
     hasBin: true
 
@@ -8043,7 +8043,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.19.0(supports-color@7.2.0)(typescript@5.9.3):
+  shadcn@4.19.1(supports-color@7.2.0)(typescript@5.9.3):
     dependencies:
       '@babel/core': 7.29.7(supports-color@7.2.0)
       '@babel/parser': 7.29.8

--- a/tooling/registry/source-manifest.mjs
+++ b/tooling/registry/source-manifest.mjs
@@ -4,7 +4,7 @@ import {
 } from "./component-items.mjs";
 
 export const DEVELOPMENT_REGISTRY_VERSION = "dev";
-export const PINNED_SHADCN_VERSION = "4.19.0";
+export const PINNED_SHADCN_VERSION = "4.19.1";
 
 const receiptFrameItem = {
   name: "docn-receipt-frame",


### PR DESCRIPTION
## Summary
- align Overview, Getting Started, and Installation with the concise official Vite, Tailwind CSS, and shadcn onboarding pattern
- keep the first-run path to requirements, install, render, and focused next steps
- qualify the current shadcn 4.19.1 patch while keeping Tailwind CSS 4.3.3 and Vite 8.2.2 current

## Validation
- format check, lint, and typecheck
- docs link verification and registry schema verification
- 62 unit/component/integration tests
- isolated consumer installation and PDF rendering with shadcn 4.19.1
- production site build
- browser verification of Overview, Getting Started, and Installation