### PR TITLE
chore(release): configure public beta deployment

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,16 @@
+.git/
+.vercel/
+.env*
+node_modules/
+**/node_modules/
+.artifacts/
+tmp/
+.codex-remote-attachments/
+apps/www/.next/
+apps/www/out/
+apps/www/public/generated/
+apps/www/public/r/
+coverage/
+playwright-report/
+test-results/
+*.log

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -30,9 +30,11 @@ The `release-policy` workflow is present but must not be added to the `main` rul
 
 ## Hosting
 
-Technical default: portable static build (`apps/www/out`). The host remains unconfirmed; Vercel, a static server, or another host are possible. Do not configure a provider simply because a plugin is available.
+Technical default: portable static build (`apps/www/out`). The maintainer selected Vercel for the public site and authorized a non-indexed beta at `https://docn-ui.vercel.app`. `vercel.json` pins the repository's package manager, exports the monorepo output, and maps the portable security/cache policy to provider headers. This beta authorization does not select a code license or authorize an official v1.0.0 tag/release.
 
 L15 provides a local preview because no destination is authorized. Run `pnpm build:preview`, then `pnpm preview:verify`; `pnpm preview` keeps the verified build available at `http://127.0.0.1:4173`. The build fingerprint records its source inputs, complete static-output digest, file/byte counts, `SITE_URL`, registry origin and indexing mode. `SITE_URL` controls canonical URLs and sitemap output. Previews are not indexed.
+
+For the authorized beta, configure the Vercel production build with `SITE_URL=https://docn-ui.vercel.app`, `DOCN_REGISTRY_ORIGIN=https://docn-ui.vercel.app/r/dev/`, and `DOCN_ALLOW_INDEXING=false`. Build locally with `vercel build --prod`, deploy the resulting `.vercel/output` with `vercel deploy --prebuilt --prod --skip-domain`, and verify the generated HTTPS URL before `vercel promote`. After promotion, repeat the probes against the stable alias and perform one installation from its public development registry. Never promote a build whose fingerprint does not match the reviewed source SHA.
 
 Static builds emit a canonical URL and sitemap entry for every public page. Without `SITE_URL`, canonicals use the loopback development origin and the complete site emits `noindex, nofollow` plus `Disallow: /`. A publication candidate becomes indexable only when it has an authorized `SITE_URL` and `DOCN_ALLOW_INDEXING=true`. Generated preview assets and development registry paths remain excluded from crawlers. Do not enable indexing merely to test a preview deployment.
 
@@ -48,9 +50,9 @@ Propose a permissive code license only after confirming the author; do not infer
 
 ### Decisions still requiring maintainer authorization
 
-- Author identity and code license.
-- Hosting provider, production origin/domain and any account or billing action.
-- Permission to publish the site and make it indexable.
+- Code license. The confirmed author is Emmanuel Osiris Balonga.
+- Any custom domain or billing action. Vercel and the `docn-ui.vercel.app` beta origin are confirmed.
+- Permission to make the site indexable. Public non-indexed beta publication is authorized.
 - Permission to create the `release-approved` label/apply it to the promotion PR, merge `dev -> main`, deploy, tag and create the GitHub release.
 
 Repository visibility is already public, but that grants none of the decisions above. No npm publication is planned for V1.

--- a/docs/implementation/github.json
+++ b/docs/implementation/github.json
@@ -680,7 +680,9 @@
       "itemId": "PVTI_lAHOCZDjCM4BhyZuzg4fVsY",
       "pullRequest": {
         "number": 53,
-        "url": "https://github.com/Osiris-Balonga/docn-ui/pull/53"
+        "url": "https://github.com/Osiris-Balonga/docn-ui/pull/53",
+        "mergeCommit": "5dbec34bcfae5fedc774a9b187d67d02be785de4",
+        "mergedAt": "2026-09-01T22:36:41Z"
       },
       "initialized": true
     },

--- a/docs/implementation/status.json
+++ b/docs/implementation/status.json
@@ -4,7 +4,7 @@
   "planDate": "2026-08-28",
   "phase": "implementation",
   "implementationStarted": true,
-  "currentLot": "L15",
+  "currentLot": "L16",
   "git": {
     "initialized": true,
     "remote": "https://github.com/Osiris-Balonga/docn-ui.git",
@@ -13,11 +13,11 @@
   "externalDecisions": {
     "repository": "Osiris-Balonga/docn-ui",
     "visibility": "public",
-    "author": null,
+    "author": "Emmanuel Osiris Balonga",
     "license": null,
-    "hosting": null,
-    "siteUrl": null,
-    "publicationAuthorized": false,
+    "hosting": "Vercel",
+    "siteUrl": "https://docn-ui.vercel.app",
+    "publicationAuthorized": true,
     "githubSetupAuthorized": true,
     "projectLanguage": "en",
     "conversationLanguage": "fr"
@@ -383,7 +383,7 @@
     {
       "id": "L15",
       "file": "lots/L15-delivery.md",
-      "state": "in_review",
+      "state": "merged",
       "dependsOn": ["L14"],
       "branch": "ci/release-delivery",
       "baseCommit": "da10836b00240f4df1919863a6cca07de92a8ee8",
@@ -394,17 +394,19 @@
         "2574c96e264ba74939539e1d0c3ceb469efc6635"
       ],
       "evidence": "../qa/L15.md",
-      "blocker": null
+      "blocker": null,
+      "mergeCommit": "5dbec34bcfae5fedc774a9b187d67d02be785de4",
+      "mergedAt": "2026-09-01T22:36:41Z"
     },
     {
       "id": "L16",
       "file": "lots/L16-release.md",
-      "state": "planned",
+      "state": "in_progress",
       "dependsOn": ["L15"],
       "branch": "release/v1.0.0",
-      "baseCommit": null,
+      "baseCommit": "5dbec34bcfae5fedc774a9b187d67d02be785de4",
       "actualCommits": [],
-      "evidence": null,
+      "evidence": "../qa/L16.md",
       "blocker": null
     }
   ],

--- a/docs/qa/L16.md
+++ b/docs/qa/L16.md
@@ -1,0 +1,33 @@
+# QA — L16 — Release candidate and public beta delivery
+
+Date: 2026-09-01. Status: **in progress**. Branch: `release/v1.0.0`, based on L15 merge `5dbec34bcfae5fedc774a9b187d67d02be785de4`.
+
+Issue [#20](https://github.com/Osiris-Balonga/docn-ui/issues/20); Project item `PVTI_lAHOCZDjCM4BhyZuzg4fVt4`. No pull request, merge, tag, GitHub release, or official v1.0.0 delivery is claimed yet.
+
+## Scope
+
+The maintainer confirmed the author identity as Emmanuel Osiris Balonga, selected Vercel as the host, and authorized a public beta deployment for colleague testing. The beta uses `https://docn-ui.vercel.app`, keeps crawler indexing disabled, and publishes the mutable development registry under `/r/dev/`. The missing project license remains an explicit blocker for the official v1.0.0 release; the MIT license used by DrawMotion was inspected as identity context but was not inferred for docn-ui.
+
+The deployment configuration pins pnpm 11.24.0, exports the monorepo site from `apps/www/out`, and maps the existing portable security and cache policy to Vercel. Production deployment must use a prebuilt artifact, be verified on its generated URL before promotion, then be checked again on the stable alias.
+
+## Verification
+
+| Command or check | Environment | Actual result | Evidence |
+| --- | --- | --- | --- |
+| Vercel account and project link | Vercel CLI 59.11.1 | Passed | Account `osiris-balonga`; project `docn-ui` (`prj_XR8jQdirki0urEGq6JQg4CdtYcUl`) under `osiris-balongas-projects`. |
+| Provider configuration test | Node 24.18.0, Vitest 4.1.11 | Pending | Must prove Vercel build/output settings and portable header-policy parity. |
+| Public beta build and fingerprint | Vercel production environment | Pending | Must record exact source SHA, output digest, file count, byte count, and build duration. |
+| Generated deployment smoke check | HTTPS | Pending | Must verify status, deep docs, registry JSON, representative PDF, assets, security headers, cache classes, and `Disallow: /`. |
+| Stable alias and public consumer installation | HTTPS | Pending | Must verify `https://docn-ui.vercel.app` only after promotion. |
+
+## Justification for added tests
+
+The provider mapping test covers the new risk that Vercel could serve a correct static artifact with incorrect caching or security headers. It extends the existing portable policy test instead of adding a parallel deployment suite.
+
+## Visual and document checks
+
+The deployment reuses the already-qualified static export and document artifacts. A representative PDF and its public MIME type will be checked after deployment; no new visual reference is required for provider-only configuration.
+
+## Deviations and resumption
+
+This is a beta publication, not the official v1.0.0 release. Indexing remains disabled and the public registry remains on `/r/dev/` until a licensed, immutable candidate is approved. Resume by validating the Vercel configuration, merging the provider setup to `dev`, building from that exact merge SHA, deploying without alias promotion, running public probes, and promoting only the verified artifact. License selection is still required before L16-S01 and the official release can complete.

--- a/tooling/deployment/static-policy.test.ts
+++ b/tooling/deployment/static-policy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
 import {
   cacheControlForPath,
   staticSecurityHeaders,
@@ -21,6 +22,60 @@ describe("portable static hosting policy", () => {
     expect(staticSecurityHeaders["X-Content-Type-Options"]).toBe("nosniff");
     expect(staticSecurityHeaders["Content-Security-Policy"]).toContain(
       "worker-src 'self' blob:",
+    );
+  });
+
+  it("maps the portable policy to the Vercel static deployment", () => {
+    const config = JSON.parse(
+      readFileSync(new URL("../../vercel.json", import.meta.url), "utf8"),
+    ) as {
+      buildCommand: string;
+      installCommand: string;
+      outputDirectory: string;
+      headers: Array<{
+        source: string;
+        headers: Array<{ key: string; value: string }>;
+      }>;
+    };
+    const headersFor = (source: string) =>
+      Object.fromEntries(
+        config.headers
+          .find((rule) => rule.source === source)!
+          .headers.map(({ key, value }) => [key, value]),
+      );
+
+    expect(config.installCommand).toContain("pnpm@11.24.0");
+    expect(config.buildCommand).toBe("corepack pnpm@11.24.0 build");
+    expect(config.outputDirectory).toBe("apps/www/out");
+    expect(headersFor("/(.*)")["Cache-Control"]).toBe(
+      cacheControlForPath("/docs/installation/index.html"),
+    );
+    expect(headersFor("/r/dev/(.*)")["Cache-Control"]).toBe(
+      cacheControlForPath("/r/dev/docn-text.json"),
+    );
+    expect(headersFor("/_next/static/(.*)")["Cache-Control"]).toBe(
+      cacheControlForPath("/_next/static/chunks/app-a1b2.js"),
+    );
+    expect(
+      headersFor("/r/v:major(\\d+).:minor(\\d+).:patch(\\d+)/(.*)")[
+        "Cache-Control"
+      ],
+    ).toBe(cacheControlForPath("/r/v1.0.0/docn-text.json"));
+    expect(headersFor("/(.*)")["Content-Security-Policy"]).toBe(
+      staticSecurityHeaders["Content-Security-Policy"],
+    );
+
+    const ignored = readFileSync(
+      new URL("../../.vercelignore", import.meta.url),
+      "utf8",
+    ).split(/\r?\n/);
+    expect(ignored).toEqual(
+      expect.arrayContaining([
+        ".artifacts/",
+        "tmp/",
+        ".codex-remote-attachments/",
+        "apps/www/out/",
+      ]),
     );
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": null,
+  "installCommand": "corepack pnpm@11.24.0 install --frozen-lockfile",
+  "buildCommand": "corepack pnpm@11.24.0 build",
+  "outputDirectory": "apps/www/out",
+  "trailingSlash": true,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; connect-src 'self' blob:; font-src 'self'; form-action 'self'; frame-ancestors 'none'; img-src 'self' blob: data:; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:"
+        },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin" },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/_next/static/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/r/dev/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/r/v:major(\\d+).:minor(\\d+).:patch(\\d+)/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- configure the authorized Vercel static beta at https://docn-ui.vercel.app`n- preserve the portable security and cache policy, with indexing disabled
- exclude local QA artifacts and attachments from provider uploads
- record confirmed author, host, publication authorization, and the unresolved license decision

## Verification

- corepack pnpm@11.24.0 exec vitest run --project unit tooling/deployment/static-policy.test.ts`n- corepack pnpm@11.24.0 format:check`n- corepack pnpm@11.24.0 verify:docs`n- ercel deploy --dry --json (383 files / 20,015,335 bytes; provider configuration accepted)

## Release boundary

This PR prepares a public, non-indexed beta. It does not select a license, create a tag/GitHub release, publish npm packages, promote dev to main, or claim the official v1.0.0 release.