### PR TITLE
fix(release): pin nested Vercel build commands

### DIFF
--- a/docs/implementation/status.json
+++ b/docs/implementation/status.json
@@ -405,7 +405,7 @@
       "dependsOn": ["L15"],
       "branch": "release/v1.0.0",
       "baseCommit": "5dbec34bcfae5fedc774a9b187d67d02be785de4",
-      "actualCommits": [],
+      "actualCommits": ["149c027ba7b4c2927715dba9e3181c0dd06ed718"],
       "evidence": "../qa/L16.md",
       "blocker": null
     }

--- a/docs/qa/L16.md
+++ b/docs/qa/L16.md
@@ -15,7 +15,8 @@ The deployment configuration pins pnpm 11.24.0, exports the monorepo site from `
 | Command or check | Environment | Actual result | Evidence |
 | --- | --- | --- | --- |
 | Vercel account and project link | Vercel CLI 59.11.1 | Passed | Account `osiris-balonga`; project `docn-ui` (`prj_XR8jQdirki0urEGq6JQg4CdtYcUl`) under `osiris-balongas-projects`. |
-| Provider configuration test | Node 24.18.0, Vitest 4.1.11 | Pending | Must prove Vercel build/output settings and portable header-policy parity. |
+| Provider configuration test | Node 24.18.0, Vitest 4.1.11 | Passed, 2 targeted cases | Vercel build/output settings, upload exclusions, and portable header-policy parity. |
+| PR #54 CI | GitHub Actions | Passed, 7 required checks | Merge `21c16a2ec5dfd487a257d6947e2e8e8108162a5c`; branch policy, quality, unit, build, PDF, E2E, and consumer checks passed. |
 | Public beta build and fingerprint | Vercel production environment | Pending | Must record exact source SHA, output digest, file count, byte count, and build duration. |
 | Generated deployment smoke check | HTTPS | Pending | Must verify status, deep docs, registry JSON, representative PDF, assets, security headers, cache classes, and `Disallow: /`. |
 | Stable alias and public consumer installation | HTTPS | Pending | Must verify `https://docn-ui.vercel.app` only after promotion. |
@@ -30,4 +31,4 @@ The deployment reuses the already-qualified static export and document artifacts
 
 ## Deviations and resumption
 
-This is a beta publication, not the official v1.0.0 release. Indexing remains disabled and the public registry remains on `/r/dev/` until a licensed, immutable candidate is approved. Resume by validating the Vercel configuration, merging the provider setup to `dev`, building from that exact merge SHA, deploying without alias promotion, running public probes, and promoting only the verified artifact. License selection is still required before L16-S01 and the official release can complete.
+This is a beta publication, not the official v1.0.0 release. Indexing remains disabled and the public registry remains on `/r/dev/` until a licensed, immutable candidate is approved. PR #54 merged the provider setup to `dev`. The first local `vercel build --prod` stopped before deployment because the root build script re-entered the host's global pnpm 11.19.0 even though the Vercel install command used the required pnpm 11.24.0. The corrective commit pins Corepack for every nested build step and must pass a new PR before the build is retried from its merge SHA. License selection is still required before L16-S01 and the official release can complete.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "pnpm generate:templates && pnpm generate:registry && pnpm --filter @docn-ui/www dev",
-    "build": "pnpm generate:templates && pnpm generate:registry && pnpm --filter @docn-ui/www build && node tooling/testing/build-fingerprint.mjs write",
+    "build": "corepack pnpm@11.24.0 generate:templates && corepack pnpm@11.24.0 generate:registry && corepack pnpm@11.24.0 --filter @docn-ui/www build && node tooling/testing/build-fingerprint.mjs write",
     "build:preview": "node tooling/deployment/build-preview.mjs",
     "generate:templates": "node tooling/templates/generate.mjs",
     "verify:templates": "node tooling/templates/generate.mjs --check",


### PR DESCRIPTION
## Summary

- pin Corepack pnpm 11.24.0 for every nested root build step
- prevent Vercel's local build from re-entering the host's pnpm 11.19.0
- record the failed pre-deployment attempt and PR #54 merge evidence

## Verification

- production-equivalent local build passed with the public beta origin and indexing disabled
- build fingerprint verified for the current checkout
- formatting passed

No deployment was created by the failed attempt.