### PR TITLE
docs(release): record verified public beta

### DIFF
--- a/docs/implementation/github.json
+++ b/docs/implementation/github.json
@@ -691,7 +691,20 @@
       "issueId": "I_kwDOUHjPN88AAAABOuNP_g",
       "issueUrl": "https://github.com/Osiris-Balonga/docn-ui/issues/20",
       "itemId": "PVTI_lAHOCZDjCM4BhyZuzg4fVt4",
-      "pullRequest": null,
+      "pullRequest": {
+        "number": 54,
+        "url": "https://github.com/Osiris-Balonga/docn-ui/pull/54",
+        "mergeCommit": "21c16a2ec5dfd487a257d6947e2e8e8108162a5c",
+        "mergedAt": "2026-09-01T23:01:54Z"
+      },
+      "followUpPullRequests": [
+        {
+          "number": 55,
+          "url": "https://github.com/Osiris-Balonga/docn-ui/pull/55",
+          "mergeCommit": "c7c16b4326013d820aebe4d519faaf10fc491f10",
+          "mergedAt": "2026-09-01T23:09:33Z"
+        }
+      ],
       "initialized": true
     }
   },

--- a/docs/implementation/status.json
+++ b/docs/implementation/status.json
@@ -405,7 +405,10 @@
       "dependsOn": ["L15"],
       "branch": "release/v1.0.0",
       "baseCommit": "5dbec34bcfae5fedc774a9b187d67d02be785de4",
-      "actualCommits": ["149c027ba7b4c2927715dba9e3181c0dd06ed718"],
+      "actualCommits": [
+        "149c027ba7b4c2927715dba9e3181c0dd06ed718",
+        "bbf88fb5fe41360f7c52f81cff9279ec97e77abd"
+      ],
       "evidence": "../qa/L16.md",
       "blocker": null
     }

--- a/docs/qa/L16.md
+++ b/docs/qa/L16.md
@@ -1,8 +1,8 @@
 # QA — L16 — Release candidate and public beta delivery
 
-Date: 2026-09-01. Status: **in progress**. Branch: `release/v1.0.0`, based on L15 merge `5dbec34bcfae5fedc774a9b187d67d02be785de4`.
+Date: 2026-09-02. Status: **public beta verified; official release in progress**. Branch: `release/v1.0.0`, based on L15 merge `5dbec34bcfae5fedc774a9b187d67d02be785de4`.
 
-Issue [#20](https://github.com/Osiris-Balonga/docn-ui/issues/20); Project item `PVTI_lAHOCZDjCM4BhyZuzg4fVt4`. No pull request, merge, tag, GitHub release, or official v1.0.0 delivery is claimed yet.
+Issue [#20](https://github.com/Osiris-Balonga/docn-ui/issues/20); Project item `PVTI_lAHOCZDjCM4BhyZuzg4fVt4`; preparation [PR #54](https://github.com/Osiris-Balonga/docn-ui/pull/54), corrective [PR #55](https://github.com/Osiris-Balonga/docn-ui/pull/55). No tag, GitHub release, `dev -> main` promotion, or official v1.0.0 delivery is claimed.
 
 ## Scope
 
@@ -17,9 +17,12 @@ The deployment configuration pins pnpm 11.24.0, exports the monorepo site from `
 | Vercel account and project link | Vercel CLI 59.11.1 | Passed | Account `osiris-balonga`; project `docn-ui` (`prj_XR8jQdirki0urEGq6JQg4CdtYcUl`) under `osiris-balongas-projects`. |
 | Provider configuration test | Node 24.18.0, Vitest 4.1.11 | Passed, 2 targeted cases | Vercel build/output settings, upload exclusions, and portable header-policy parity. |
 | PR #54 CI | GitHub Actions | Passed, 7 required checks | Merge `21c16a2ec5dfd487a257d6947e2e8e8108162a5c`; branch policy, quality, unit, build, PDF, E2E, and consumer checks passed. |
-| Public beta build and fingerprint | Vercel production environment | Pending | Must record exact source SHA, output digest, file count, byte count, and build duration. |
-| Generated deployment smoke check | HTTPS | Pending | Must verify status, deep docs, registry JSON, representative PDF, assets, security headers, cache classes, and `Disallow: /`. |
-| Stable alias and public consumer installation | HTTPS | Pending | Must verify `https://docn-ui.vercel.app` only after promotion. |
+| PR #55 corrective CI | GitHub Actions | Passed, 7 required checks | Merge `c7c16b4326013d820aebe4d519faaf10fc491f10`; branch policy, quality, unit, build, PDF, E2E, and consumer checks passed. |
+| Public beta build and fingerprint | Vercel CLI 59.11.1, Node 24.18.0 | Passed | Source `c7c16b4326013d820aebe4d519faaf10fc491f10`; input SHA-256 `21f9513563c9051134153db855a19131ccdf994b8bce4f7a46c786c7149a42fd`; output SHA-256 `118c71b19dc56219a1df29452ad903b3ecffa5ca05531bb9022e32cf07ba7eae`; 454 files / 33,968,658 bytes; local prebuild completed in approximately 45.5 seconds. |
+| Isolated deployment smoke check | Vercel deployment protection bypass | Passed | Deployment `dpl_FQTzuUhL7ck6gAjUVrmyuZ9XdvHW` reached READY. Home, `/docs/installation/`, development registry JSON, representative PDF, and hashed JavaScript returned 200 with expected MIME, CSP, security, and cache headers. `robots.txt` returned `Disallow: /`. |
+| Stable alias anonymous smoke check | Public HTTPS | Passed | `https://docn-ui.vercel.app` and the same representative deep paths returned 200 without authentication after promotion. HTML/PDF revalidate; `/r/dev/` is no-store; hashed JavaScript is immutable. |
+| Public shadcn installation | shadcn 4.19.1, pnpm 11.24.0 | Passed | Installing `https://docn-ui.vercel.app/r/dev/docn-text.json` in a temporary external consumer created eight source files and installed exact React 19.2.8, React PDF 4.9.0, and Zod 3.25.76 dependencies. |
+| Production error log query | Vercel CLI 59.11.1 | Passed | No error logs were present; the deployment contains static output only and no Vercel Functions. |
 
 ## Justification for added tests
 
@@ -27,8 +30,10 @@ The provider mapping test covers the new risk that Vercel could serve a correct 
 
 ## Visual and document checks
 
-The deployment reuses the already-qualified static export and document artifacts. A representative PDF and its public MIME type will be checked after deployment; no new visual reference is required for provider-only configuration.
+The deployment reuses the already-qualified static export and document artifacts. The public `invoice-photo-header.pdf` returned 200 with `Content-Type: application/pdf`, byte length 2,114,774, and the expected security/cache policy. No visual reference changed, so no new visual baseline was created.
 
 ## Deviations and resumption
 
-This is a beta publication, not the official v1.0.0 release. Indexing remains disabled and the public registry remains on `/r/dev/` until a licensed, immutable candidate is approved. PR #54 merged the provider setup to `dev`. The first local `vercel build --prod` stopped before deployment because the root build script re-entered the host's global pnpm 11.19.0 even though the Vercel install command used the required pnpm 11.24.0. The corrective commit pins Corepack for every nested build step and must pass a new PR before the build is retried from its merge SHA. License selection is still required before L16-S01 and the official release can complete.
+This is a beta publication, not the official v1.0.0 release. Indexing remains disabled and the public registry remains on `/r/dev/` until a licensed, immutable candidate is approved. The first local `vercel build --prod` stopped before deployment because the root build script re-entered the host's global pnpm 11.19.0 even though the Vercel install command used the required pnpm 11.24.0. PR #55 pinned Corepack for every nested build step; the build was then repeated from its merge SHA and the resulting prebuilt artifact was deployed and promoted only after isolated verification.
+
+The generated deployment URL is protected by Vercel Standard Protection, while the active production domain is publicly accessible as intended. The first public consumer command also found the host's global pnpm 11.19.0; repeating it with the documented pnpm 11.24.0 Corepack shim succeeded. License selection remains required before L16-S01, immutable `/r/v1.0.0/`, `dev -> main`, tag, and official GitHub release can complete.


### PR DESCRIPTION
## Summary

- record the exact Vercel deployment, source SHA, build fingerprint, and public origin
- record anonymous deep-link, registry, PDF, asset, security, cache, and robots verification
- record one successful public shadcn installation and the pnpm host deviation
- preserve L16 as in progress because the code license and official v1.0.0 release remain unresolved

## Verification

- public beta: https://docn-ui.vercel.app
- deployment: dpl_FQTzuUhL7ck6gAjUVrmyuZ9XdvHW (READY)
- source: c7c16b4326013d820aebe4d519faaf10fc491f10
- corepack pnpm@11.24.0 verify:docs`n- production error log query returned no errors