### PR TITLE
docs(release): record licensed beta deployment

### DIFF
--- a/docs/implementation/status.json
+++ b/docs/implementation/status.json
@@ -408,7 +408,9 @@
       "actualCommits": [
         "149c027ba7b4c2927715dba9e3181c0dd06ed718",
         "bbf88fb5fe41360f7c52f81cff9279ec97e77abd",
-        "8a999444c1b235a6d90ae0e95f6b6b593b62a973"
+        "8a999444c1b235a6d90ae0e95f6b6b593b62a973",
+        "c1b3a9b15e83ad2fda5a934aa534489ce8a17af4",
+        "33c68a723dd809976319b6ed3b21a007f0af952a"
       ],
       "evidence": "../qa/L16.md",
       "blocker": null

--- a/docs/qa/L16.md
+++ b/docs/qa/L16.md
@@ -2,7 +2,7 @@
 
 Date: 2026-09-02. Status: **public beta verified; official release in progress**. Branch: `release/v1.0.0`, based on L15 merge `5dbec34bcfae5fedc774a9b187d67d02be785de4`.
 
-Issue [#20](https://github.com/Osiris-Balonga/docn-ui/issues/20); Project item `PVTI_lAHOCZDjCM4BhyZuzg4fVt4`; preparation [PR #54](https://github.com/Osiris-Balonga/docn-ui/pull/54), corrective [PR #55](https://github.com/Osiris-Balonga/docn-ui/pull/55). No tag, GitHub release, `dev -> main` promotion, or official v1.0.0 delivery is claimed.
+Issue [#20](https://github.com/Osiris-Balonga/docn-ui/issues/20); Project item `PVTI_lAHOCZDjCM4BhyZuzg4fVt4`; preparation [PR #54](https://github.com/Osiris-Balonga/docn-ui/pull/54), corrective [PR #55](https://github.com/Osiris-Balonga/docn-ui/pull/55), beta record [PR #56](https://github.com/Osiris-Balonga/docn-ui/pull/56), and MIT application [PR #57](https://github.com/Osiris-Balonga/docn-ui/pull/57). No tag, GitHub release, `dev -> main` promotion, or official v1.0.0 delivery is claimed.
 
 ## Scope
 
@@ -19,11 +19,14 @@ The deployment configuration pins pnpm 11.24.0, exports the monorepo site from `
 | MIT license propagation | Node 24.18.0, Vitest 4.1.11 | Passed, 4 targeted registry cases plus inventory checks | Root/package metadata, identical repository/installed notices, `docn/LICENSE` in every item closure, 62 generated registry items, 5 separately licensed assets, and 2,564 documentation links verified. |
 | PR #54 CI | GitHub Actions | Passed, 7 required checks | Merge `21c16a2ec5dfd487a257d6947e2e8e8108162a5c`; branch policy, quality, unit, build, PDF, E2E, and consumer checks passed. |
 | PR #55 corrective CI | GitHub Actions | Passed, 7 required checks | Merge `c7c16b4326013d820aebe4d519faaf10fc491f10`; branch policy, quality, unit, build, PDF, E2E, and consumer checks passed. |
+| PR #57 MIT CI | GitHub Actions | Passed, 7 required checks | Merge `2b589154686f75b27b96eac2d0014b72d21ac158`; branch policy, quality, unit, build, PDF, E2E, and consumer checks passed. The consumer check verifies the installed MIT notice in browser and Node projects. |
 | Public beta build and fingerprint | Vercel CLI 59.11.1, Node 24.18.0 | Passed | Source `c7c16b4326013d820aebe4d519faaf10fc491f10`; input SHA-256 `21f9513563c9051134153db855a19131ccdf994b8bce4f7a46c786c7149a42fd`; output SHA-256 `118c71b19dc56219a1df29452ad903b3ecffa5ca05531bb9022e32cf07ba7eae`; 454 files / 33,968,658 bytes; local prebuild completed in approximately 45.5 seconds. |
 | Isolated deployment smoke check | Vercel deployment protection bypass | Passed | Deployment `dpl_FQTzuUhL7ck6gAjUVrmyuZ9XdvHW` reached READY. Home, `/docs/installation/`, development registry JSON, representative PDF, and hashed JavaScript returned 200 with expected MIME, CSP, security, and cache headers. `robots.txt` returned `Disallow: /`. |
 | Stable alias anonymous smoke check | Public HTTPS | Passed | `https://docn-ui.vercel.app` and the same representative deep paths returned 200 without authentication after promotion. HTML/PDF revalidate; `/r/dev/` is no-store; hashed JavaScript is immutable. |
 | Public shadcn installation | shadcn 4.19.1, pnpm 11.24.0 | Passed | Installing `https://docn-ui.vercel.app/r/dev/docn-text.json` in a temporary external consumer created eight source files and installed exact React 19.2.8, React PDF 4.9.0, and Zod 3.25.76 dependencies. |
 | Production error log query | Vercel CLI 59.11.1 | Passed | No error logs were present; the deployment contains static output only and no Vercel Functions. |
+| Licensed beta build and fingerprint | Vercel CLI 59.11.1, Node 24.18.0 | Passed | Source `2b589154686f75b27b96eac2d0014b72d21ac158`; input SHA-256 `f5080ee51410588ff5c5967a87866920909239ffdee20e0332900240d4184954`; output SHA-256 `2ec184b2d4fa62504d72f9558925ed6f068ac5b3b46b81524cf2c8d9e7ef0efd`; 454 files / 33,970,212 bytes. |
+| Licensed beta promotion | Vercel CLI 59.11.1 and public HTTPS | Passed | Deployment `dpl_C2cnwaVHtVgDUrDViti9FPBWJxza` reached READY, was verified before promotion, and became the active deployment for `https://docn-ui.vercel.app`. The stable documentation and registry returned 200, `docn-contracts.json` contained `~/docn/LICENSE` with the confirmed copyright holder, and the post-promotion error query returned no entries. |
 
 ## Justification for added tests
 
@@ -37,4 +40,4 @@ The deployment reuses the already-qualified static export and document artifacts
 
 This is a beta publication, not the official v1.0.0 release. Indexing remains disabled and the public registry remains on `/r/dev/` until a licensed, immutable candidate is approved. The first local `vercel build --prod` stopped before deployment because the root build script re-entered the host's global pnpm 11.19.0 even though the Vercel install command used the required pnpm 11.24.0. PR #55 pinned Corepack for every nested build step; the build was then repeated from its merge SHA and the resulting prebuilt artifact was deployed and promoted only after isolated verification.
 
-The generated deployment URL is protected by Vercel Standard Protection, while the active production domain is publicly accessible as intended. The first public consumer command also found the host's global pnpm 11.19.0; repeating it with the documented pnpm 11.24.0 Corepack shim succeeded. License selection remains required before L16-S01, immutable `/r/v1.0.0/`, `dev -> main`, tag, and official GitHub release can complete.
+The generated deployment URL is protected by Vercel Standard Protection, while the active production domain is publicly accessible as intended. The first public consumer command also found the host's global pnpm 11.19.0; repeating it with the documented pnpm 11.24.0 Corepack shim succeeded. MIT selection and propagation are complete. Immutable `/r/v1.0.0/`, explicit release approval, `dev -> main`, tag, and the official GitHub release remain before L16 can complete.


### PR DESCRIPTION
## Summary
- record PR #57 and its seven passing required checks
- record the exact licensed-beta source commit, build fingerprints, deployment ID, public registry notice, and clean error scan
- keep L16 explicitly in progress without claiming an official v1.0.0 release

## Verification
- corepack pnpm@11.24.0 verify:docs
- git diff --check
- isolated deployment and stable alias returned 200
- public docn-contracts registry item contains docn/LICENSE with the confirmed copyright holder
- Vercel production error query returned no entries

## Release boundary
This tracking PR does not create an immutable v1 registry, main promotion, tag, GitHub release, or npm publication.