### PR TITLE
release: promote template installation fixes

### DIFF
--- a/apps/www/src/features/catalog/template-catalog.tsx
+++ b/apps/www/src/features/catalog/template-catalog.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { CheckIcon, Code2Icon, CopyIcon } from "lucide-react";
+import { CheckIcon, Code2Icon, TerminalIcon } from "lucide-react";
 import {
   templateCatalog,
   templateFamilies,
@@ -62,9 +62,11 @@ function TemplateActions({ template }: { template: TemplateCatalogEntry }) {
         {copied ? (
           <CheckIcon aria-hidden="true" />
         ) : (
-          <CopyIcon aria-hidden="true" />
+          <TerminalIcon aria-hidden="true" />
         )}
-        <span className="hidden sm:inline">{copied ? "Copied" : "Copy"}</span>
+        <span className="hidden sm:inline">
+          {copied ? "Copied" : "Install"}
+        </span>
       </Button>
       <Sheet>
         <SheetTrigger

--- a/apps/www/src/features/docs/docs-search.tsx
+++ b/apps/www/src/features/docs/docs-search.tsx
@@ -65,7 +65,7 @@ export function DocsSearch({ overMedia = false }: { overMedia?: boolean }) {
         className={cn(
           "hidden h-8 justify-start rounded-lg border-none bg-muted px-3 text-muted-foreground shadow-none transition-colors hover:bg-muted/50 sm:flex sm:w-36 md:w-48 lg:w-40 xl:w-64 dark:bg-card",
           overMedia &&
-            "border border-white/15 bg-black/20 text-white/70 shadow-sm backdrop-blur-md hover:bg-black/35 hover:text-white",
+            "border border-white/20 bg-transparent text-white/75 shadow-none backdrop-blur-md hover:bg-white/10 hover:text-white dark:bg-transparent dark:hover:bg-white/10",
         )}
         onClick={() => setOpen(true)}
         aria-label="Search documentation"

--- a/apps/www/src/features/docs/shell-navigation.test.tsx
+++ b/apps/www/src/features/docs/shell-navigation.test.tsx
@@ -125,3 +125,11 @@ test("documentation search isolates editor shortcuts, reports no matches, and op
   await user.click(screen.getByText("Browser and Node"));
   expect(routerPush).toHaveBeenCalledWith("/docs/browser-and-node/");
 });
+
+test("the homepage search trigger stays transparent over the video", () => {
+  render(<SiteHeader overMedia />);
+
+  expect(
+    screen.getByRole("button", { name: "Search documentation" }),
+  ).toHaveClass("bg-transparent", "dark:bg-transparent");
+});

--- a/apps/www/src/features/registry/registry-source-panel.test.tsx
+++ b/apps/www/src/features/registry/registry-source-panel.test.tsx
@@ -166,6 +166,14 @@ describe("registry source panel", () => {
     expect(screen.queryByRole("combobox", { name: "Source file" })).toBeNull();
     expect(screen.queryByText("2 files · 2 registry items")).toBeNull();
     expect(
+      screen.getByRole("button", { name: "Copy install command" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /shadcn@4\.19\.1 add .*\/r\/dev\/docn-component-example\.json/,
+      ),
+    ).toBeInTheDocument();
+    expect(
       screen.getByLabelText("~/docn/examples/card.tsx source"),
     ).toHaveTextContent('export const Card = "composed source";');
     expect(screen.getByText("layout.tsx")).toBeInTheDocument();

--- a/apps/www/src/features/registry/registry-source-panel.tsx
+++ b/apps/www/src/features/registry/registry-source-panel.tsx
@@ -331,7 +331,22 @@ export function RegistrySourcePanel({
         )}
       </div>
 
-      {!drawer ? (
+      {drawer ? (
+        <div className="mt-3 flex min-w-0 items-center gap-3 rounded-lg border bg-muted/35 p-2 pl-3">
+          <Terminal
+            aria-hidden="true"
+            className="size-4 shrink-0 text-muted-foreground"
+          />
+          <code className="min-w-0 flex-1 truncate text-xs">
+            {installCommand}
+          </code>
+          <CopyAction
+            compact
+            label="Copy install command"
+            text={installCommand}
+          />
+        </div>
+      ) : (
         <>
           <div className="mt-6 grid gap-4 lg:grid-cols-2">
             <CommandBlock
@@ -349,7 +364,7 @@ export function RegistrySourcePanel({
             overwrite flags.
           </p>
         </>
-      ) : null}
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Production changes
- keep homepage search transparent over the video
- expose template installation as an explicit catalog action
- show the complete shadcn install command in the source drawer

## Evidence
- PR #61 passed branch-policy, quality, unit-tests, pdf-tests, consumer-tests, build and e2e-chromium
- public registry item resolved successfully through shadcn 4.19.1