### PR TITLE
fix(catalog): address beta catalog feedback

### DIFF
--- a/apps/www/src/app/(site)/components/page.tsx
+++ b/apps/www/src/app/(site)/components/page.tsx
@@ -43,17 +43,6 @@ export default function ComponentsPage() {
         description="Here you can find all the PDF components available in the library. Explore their previews, code and API."
         hideBreadcrumb
       >
-        <section aria-labelledby="new-components">
-          <h2
-            id="new-components"
-            className="scroll-m-20 text-xl font-semibold tracking-tight"
-          >
-            New Components
-          </h2>
-          <div className="mt-3">
-            <ComponentLink slug="barcode" title="Barcode" isNew />
-          </div>
-        </section>
         <section aria-labelledby="all-components">
           <h2
             id="all-components"
@@ -64,7 +53,11 @@ export default function ComponentsPage() {
           <ul className="mt-4 grid grid-cols-2 gap-x-8 gap-y-1 sm:grid-cols-3">
             {componentCatalog.map((entry) => (
               <li key={entry.slug}>
-                <ComponentLink slug={entry.slug} title={entry.title} />
+                <ComponentLink
+                  slug={entry.slug}
+                  title={entry.title}
+                  isNew={entry.slug === "barcode"}
+                />
               </li>
             ))}
           </ul>

--- a/apps/www/src/features/catalog/template-catalog.tsx
+++ b/apps/www/src/features/catalog/template-catalog.tsx
@@ -1,15 +1,9 @@
 "use client";
 
-import {
-  type KeyboardEvent,
-  Suspense,
-  useEffect,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import { type KeyboardEvent, Suspense, useEffect } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { CheckIcon, Code2Icon, TerminalIcon } from "lucide-react";
+import { Code2Icon } from "lucide-react";
 import {
   templateCatalog,
   templateFamilies,
@@ -27,47 +21,11 @@ import {
 } from "@/components/ui/sheet";
 import { RegistrySourcePanel } from "@/features/registry/registry-source-panel";
 import { PdfPreviewDialog } from "@/features/pdf-preview/pdf-preview-dialog";
-import { copyText } from "@/features/registry/registry-source";
 import { cn } from "@/lib/utils";
 
-const subscribeToStaticOrigin = () => () => {};
-
 function TemplateActions({ template }: { template: TemplateCatalogEntry }) {
-  const [copied, setCopied] = useState(false);
-  const origin = useSyncExternalStore(
-    subscribeToStaticOrigin,
-    () => window.location.origin,
-    () => "http://127.0.0.1:4173",
-  );
-  const installCommand = `corepack pnpm dlx shadcn@4.19.1 add ${origin}/r/dev/docn-${template.id}.json`;
-
-  async function copyInstallCommand() {
-    const success = await copyText(installCommand).catch(() => false);
-    setCopied(success);
-  }
-
   return (
-    <div className="flex items-center gap-1">
-      <Button
-        type="button"
-        variant="ghost"
-        className="h-10 px-2.5"
-        onClick={copyInstallCommand}
-        aria-label={
-          copied
-            ? `Copied ${template.title} install command`
-            : `Copy ${template.title} install command`
-        }
-      >
-        {copied ? (
-          <CheckIcon aria-hidden="true" />
-        ) : (
-          <TerminalIcon aria-hidden="true" />
-        )}
-        <span className="hidden sm:inline">
-          {copied ? "Copied" : "Install"}
-        </span>
-      </Button>
+    <div className="flex items-center">
       <Sheet>
         <SheetTrigger
           render={

--- a/apps/www/src/features/docs/docs-on-this-page.tsx
+++ b/apps/www/src/features/docs/docs-on-this-page.tsx
@@ -13,10 +13,7 @@ const pageSections: Record<string, readonly { title: string; href: string }[]> =
         href: "#development-installation",
       },
     ],
-    "/components/": [
-      { title: "New Components", href: "#new-components" },
-      { title: "All Components", href: "#all-components" },
-    ],
+    "/components/": [{ title: "All Components", href: "#all-components" }],
   };
 
 export function DocsOnThisPage({

--- a/apps/www/src/features/docs/docs-search.tsx
+++ b/apps/www/src/features/docs/docs-search.tsx
@@ -65,7 +65,7 @@ export function DocsSearch({ overMedia = false }: { overMedia?: boolean }) {
         className={cn(
           "hidden h-8 justify-start rounded-lg border-none bg-muted px-3 text-muted-foreground shadow-none transition-colors hover:bg-muted/50 sm:flex sm:w-36 md:w-48 lg:w-40 xl:w-64 dark:bg-card",
           overMedia &&
-            "border border-white/20 bg-transparent text-white/75 shadow-none backdrop-blur-md hover:bg-white/10 hover:text-white dark:bg-transparent dark:hover:bg-white/10",
+            "border border-white/25 bg-black/20 text-white/80 shadow-sm shadow-black/20 backdrop-blur-md hover:bg-black/35 hover:text-white dark:bg-black/20 dark:hover:bg-black/35",
         )}
         onClick={() => setOpen(true)}
         aria-label="Search documentation"

--- a/apps/www/src/features/docs/shell-navigation.test.tsx
+++ b/apps/www/src/features/docs/shell-navigation.test.tsx
@@ -58,7 +58,7 @@ test("the shell exposes a focused skip link and an operable mobile documentation
     within(primaryNavigation).getByRole("link", { name: "Components" }),
   ).toBeInTheDocument();
   expect(
-    within(primaryNavigation).getByRole("link", { name: "Template" }),
+    within(primaryNavigation).getByRole("link", { name: "Templates" }),
   ).toBeInTheDocument();
   expect(
     screen.getByRole("link", { name: "Open docn-ui on GitHub" }),
@@ -126,10 +126,10 @@ test("documentation search isolates editor shortcuts, reports no matches, and op
   expect(routerPush).toHaveBeenCalledWith("/docs/browser-and-node/");
 });
 
-test("the homepage search trigger stays transparent over the video", () => {
+test("the homepage search trigger remains identifiable over the video", () => {
   render(<SiteHeader overMedia />);
 
   expect(
     screen.getByRole("button", { name: "Search documentation" }),
-  ).toHaveClass("bg-transparent", "dark:bg-transparent");
+  ).toHaveClass("border-white/25", "bg-black/20", "shadow-sm");
 });

--- a/apps/www/src/features/docs/site-footer.tsx
+++ b/apps/www/src/features/docs/site-footer.tsx
@@ -26,7 +26,7 @@ export function SiteFooter({ overMedia = false }: { overMedia?: boolean }) {
                 href="/templates/"
                 className="flex min-h-10 items-center outline-none transition-colors hover:text-foreground focus-visible:rounded-sm focus-visible:ring-3 focus-visible:ring-ring/50"
               >
-                Template
+                Templates
               </Link>
             </li>
             <li>

--- a/apps/www/src/features/docs/site-navigation.tsx
+++ b/apps/www/src/features/docs/site-navigation.tsx
@@ -20,7 +20,7 @@ const primaryNavigation = [
   { title: "Home", href: "/" },
   { title: "Docs", href: "/docs/" },
   { title: "Components", href: "/components/" },
-  { title: "Template", href: "/templates/" },
+  { title: "Templates", href: "/templates/" },
 ] as const;
 
 function isActive(pathname: string, href: string) {

--- a/apps/www/src/features/registry/registry-source-panel.test.tsx
+++ b/apps/www/src/features/registry/registry-source-panel.test.tsx
@@ -168,14 +168,16 @@ describe("registry source panel", () => {
     expect(
       screen.getByRole("button", { name: "Copy install command" }),
     ).toBeInTheDocument();
+    const installCommand = screen.getByText(
+      /shadcn@4\.19\.1 add .*\/r\/dev\/docn-component-example\.json/,
+    );
+    const source = screen.getByLabelText("~/docn/examples/card.tsx source");
+    expect(installCommand).toBeInTheDocument();
     expect(
-      screen.getByText(
-        /shadcn@4\.19\.1 add .*\/r\/dev\/docn-component-example\.json/,
-      ),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByLabelText("~/docn/examples/card.tsx source"),
-    ).toHaveTextContent('export const Card = "composed source";');
+      installCommand.compareDocumentPosition(source) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(source).toHaveTextContent('export const Card = "composed source";');
     expect(screen.getByText("layout.tsx")).toBeInTheDocument();
     expect(screen.getByText("schema.ts")).toBeInTheDocument();
     expect(screen.getByText("examples.ts")).toBeInTheDocument();

--- a/apps/www/src/features/registry/registry-source-panel.tsx
+++ b/apps/www/src/features/registry/registry-source-panel.tsx
@@ -204,6 +204,22 @@ export function RegistrySourcePanel({
       <h2 id={headingId} className="sr-only">
         Component source
       </h2>
+      {drawer ? (
+        <div className="mb-3 flex min-w-0 items-center gap-3 rounded-lg border bg-muted/35 p-2 pl-3">
+          <Terminal
+            aria-hidden="true"
+            className="size-4 shrink-0 text-muted-foreground"
+          />
+          <code className="min-w-0 flex-1 truncate text-xs">
+            {installCommand}
+          </code>
+          <CopyAction
+            compact
+            label="Copy install command"
+            text={installCommand}
+          />
+        </div>
+      ) : null}
       <div
         className={cn(
           "overflow-hidden rounded-lg border bg-card",
@@ -331,22 +347,7 @@ export function RegistrySourcePanel({
         )}
       </div>
 
-      {drawer ? (
-        <div className="mt-3 flex min-w-0 items-center gap-3 rounded-lg border bg-muted/35 p-2 pl-3">
-          <Terminal
-            aria-hidden="true"
-            className="size-4 shrink-0 text-muted-foreground"
-          />
-          <code className="min-w-0 flex-1 truncate text-xs">
-            {installCommand}
-          </code>
-          <CopyAction
-            compact
-            label="Copy install command"
-            text={installCommand}
-          />
-        </div>
-      ) : (
+      {drawer ? null : (
         <>
           <div className="mt-6 grid gap-4 lg:grid-cols-2">
             <CommandBlock

--- a/tests/e2e/catalog.spec.ts
+++ b/tests/e2e/catalog.spec.ts
@@ -224,7 +224,7 @@ test("browses component examples source formats and themes", async ({
   ).toBeVisible();
   await expect(
     page.getByRole("heading", { name: "New Components" }),
-  ).toBeVisible();
+  ).toHaveCount(0);
   await expect(
     page.getByRole("heading", { name: "All Components" }),
   ).toBeVisible();
@@ -232,7 +232,9 @@ test("browses component examples source formats and themes", async ({
   await expect(page.getByText("Browse templates")).toHaveCount(0);
   const inventory = page.getByRole("region", { name: "All Components" });
   await expect(inventory.getByRole("link")).toHaveCount(28);
-  await inventory.getByRole("link", { name: "Barcode", exact: true }).click();
+  const barcodeLink = inventory.getByRole("link", { name: "Barcode New" });
+  await expect(barcodeLink).toBeVisible();
+  await barcodeLink.click();
   await expect(page.getByRole("heading", { level: 1 })).toHaveText("Barcode");
   const specimen = page.getByRole("img", {
     name: "Barcode PDF example, page 1",


### PR DESCRIPTION
## Summary
- make the homepage search control visibly translucent and pluralize Templates navigation labels
- remove redundant per-card install actions and surface the install command above template source
- keep new component signaling inside the unified component list

## Verification
- corepack pnpm@11.24.0 test:components
- corepack pnpm@11.24.0 --filter @docn-ui/www typecheck
- targeted ESLint
- local browser verification at desktop and responsive layouts