### PR TITLE
feat(analytics): add privacy-minimal Vercel traffic collection

### DIFF
--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@base-ui/react": "1.7.0",
     "@docn-ui/documents": "workspace:*",
+    "@vercel/analytics": "2.0.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",

--- a/apps/www/src/app/layout.tsx
+++ b/apps/www/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { Analytics } from "@/components/analytics";
 import { ThemeProvider } from "@/features/theme/theme-provider";
 import { siteIsIndexable, siteUrl } from "@/lib/site-metadata";
 import "./globals.css";
@@ -20,6 +21,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en" suppressHydrationWarning>
       <body className="min-h-svh bg-background font-sans text-foreground antialiased">
         <ThemeProvider>{children}</ThemeProvider>
+        <Analytics />
       </body>
     </html>
   );

--- a/apps/www/src/components/analytics.tsx
+++ b/apps/www/src/components/analytics.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { Analytics as VercelAnalytics } from "@vercel/analytics/react";
+
+export function Analytics() {
+  return <VercelAnalytics />;
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,9 +85,9 @@ Enumerate dynamic routes with `generateStaticParams`; no arbitrary runtime slugs
 
 No Server Actions, generation API, request-dependent middleware, authentication cookies, ISR, or server image optimizer. Generate catalog images at build time and serve local files; explicitly configure an export-compatible mode. Security headers come from the host, not a Next API unavailable in static export.
 
-## Privacy-minimal analytics
+## Privacy-minimal hybrid analytics
 
-The static site may emit the bounded anonymous events defined by [ADR 0005](adr/0005-privacy-minimal-analytics.md). Analytics is cookieless, manual, and optional. It does not add a site API, authentication, remote document storage, user profiles, replay, or free-form event properties. The browser receives only a public ingestion token; privileged queries remain in the separate private analytics repository.
+The static site may emit the bounded anonymous events defined by [ADR 0005](adr/0005-privacy-minimal-analytics.md). Vercel Web Analytics records anonymous page views for traffic, country, route, and referrer reporting. PostHog records only manual, allowlisted product actions and remains optional. Both paths are cookieless. They do not add a site API, authentication, remote document storage, user profiles, replay, or free-form event properties. The browser receives only a public PostHog ingestion token; privileged PostHog and Vercel queries remain in the separate private analytics repository. The dashboard does not join visitor identities across providers.
 
 Serve matching versions of PDF.js/generator workers, fonts, and any required CMaps locally. L02 proves production resolution, not just `dev` resolution.
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -4,17 +4,17 @@ Resolved on 2026-08-29 from the npm registry. Versions are exact in manifests an
 
 ## Bootstrap (L01-S01)
 
-| Dependency | Version | License | Reason and browser impact |
-| --- | --- | --- | --- |
-| Node.js | 24.18.0 | Node.js license | Installed LTS runtime; pinned in .node-version and CI; no browser payload |
-| pnpm | 11.24.0 | MIT | Workspace and frozen lockfile; no browser payload |
-| Next.js | 16.3.3 | MIT | Static App Router export; framework client runtime only, no deployed Node server |
-| React / React DOM | 19.2.8 | MIT | Matching stable pair within Next's peer range; shared UI runtime |
-| TypeScript | 5.9.3 | Apache-2.0 | Conservative supported compiler; defer the newer major migration; build only |
-| @types/node | 24.13.3 | MIT | Matches the runtime major; types only |
-| @types/react / @types/react-dom | 19.2.18 / 19.2.5 | MIT | Matches React 19; types only |
-| cross-env | 10.1.0 | MIT | Disable Next telemetry in portable scripts; tooling only |
-| http-server | 14.1.1 | MIT | Serve the exported files on loopback with real 404 handling; tooling only |
+| Dependency                      | Version          | License         | Reason and browser impact                                                        |
+| ------------------------------- | ---------------- | --------------- | -------------------------------------------------------------------------------- |
+| Node.js                         | 24.18.0          | Node.js license | Installed LTS runtime; pinned in .node-version and CI; no browser payload        |
+| pnpm                            | 11.24.0          | MIT             | Workspace and frozen lockfile; no browser payload                                |
+| Next.js                         | 16.3.3           | MIT             | Static App Router export; framework client runtime only, no deployed Node server |
+| React / React DOM               | 19.2.8           | MIT             | Matching stable pair within Next's peer range; shared UI runtime                 |
+| TypeScript                      | 5.9.3            | Apache-2.0      | Conservative supported compiler; defer the newer major migration; build only     |
+| @types/node                     | 24.13.3          | MIT             | Matches the runtime major; types only                                            |
+| @types/react / @types/react-dom | 19.2.18 / 19.2.5 | MIT             | Matches React 19; types only                                                     |
+| cross-env                       | 10.1.0           | MIT             | Disable Next telemetry in portable scripts; tooling only                         |
+| http-server                     | 14.1.1           | MIT             | Serve the exported files on loopback with real 404 handling; tooling only        |
 
 Node is restricted to the qualified 24.x LTS line. The installed runtime satisfies all declared package engines. `sharp` is the only approved installation build in S01; it is a Next dependency, not a browser dependency. The maintainer selected MIT for docn-ui on 2026-09-02; dependency licenses remain separate obligations and do not change the repository license.
 
@@ -22,25 +22,27 @@ Sources: [Next static exports](https://nextjs.org/docs/app/guides/static-exports
 
 ## Privacy-minimal analytics (maintainer-directed pre-release change)
 
-| Dependency | Version | License | Reason and browser impact |
-| --- | --- | --- | --- |
+| Dependency | Version | License            | Reason and browser impact                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| ---------- | ------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | posthog-js | 1.427.0 | Apache-2.0 AND MIT | Cookieless EU event ingestion with a maintained browser SDK. Client instrumentation dynamically imports the slim/no-external entry. Autocapture, profiles, replay, surveys, tours, conversations, flags, experiments, performance, heatmaps, and external dependency loading are disabled. The measured impact is +1,573 gzip bytes on initial scripts plus a 49,990-byte gzip deferred chunk when configured; the 21,281,003-byte unpacked npm archive includes optional modules and source artifacts. |
 
 The SDK adds 11 locked package entries. `core-js@3.50.0` has a nonessential informational postinstall and is explicitly denied build-script execution; no native binary or generated runtime file is required. The same-day packages are enumerated in `minimumReleaseAgeExclude` because the maintainer explicitly requested implementation now; exact versions and the frozen lockfile preserve reproducibility. The CSP permits only the EU ingestion origin under `connect-src` and does not permit remote PostHog scripts.
 
+The hybrid traffic layer adds `@vercel/analytics@2.0.1` (MIT). Its Next.js/React adapter injects Vercel's same-origin page-view script and adds one locked package entry; no analytics access credential is shipped to the browser. The package's published unpacked size is 497,331 bytes, while the actual emitted client impact is recorded in the analytics QA evidence. Vercel Web Analytics is used only for page views, routes, countries, and referrers; PostHog remains the source for allowlisted product actions.
+
 ## Interface (L01-S02)
 
-| Dependency | Version | License | Reason and browser impact |
-| --- | --- | --- | --- |
-| shadcn CLI / CSS helpers | 4.19.1 | MIT | Source generation and compile-time Tailwind helpers; dev dependency, no CLI JavaScript in browser |
-| @base-ui/react | 1.7.0 | MIT | Button and Tooltip primitives; imported through component subpaths |
-| Tailwind CSS / PostCSS plugin | 4.3.3 | MIT | Build-time utility generation; emitted CSS only |
-| class-variance-authority | 0.7.1 | Apache-2.0 | Generated Button variants; small client utility |
-| clsx | 2.1.1 | MIT | Generated class composition utility |
-| tailwind-merge | 3.6.0 | MIT | Generated class conflict resolution; client code |
-| lucide-react | 1.34.0 | ISC | One named arrow icon; no icon gallery imported |
-| tw-animate-css | 1.4.0 | MIT | Tooltip CSS animations; global reduced-motion override |
-| Geist font assets | 1.7.2 | OFL-1.1 | Two local variable WOFF2 files, 141020 bytes total; no runtime package or external font requests |
+| Dependency                    | Version | License    | Reason and browser impact                                                                         |
+| ----------------------------- | ------- | ---------- | ------------------------------------------------------------------------------------------------- |
+| shadcn CLI / CSS helpers      | 4.19.1  | MIT        | Source generation and compile-time Tailwind helpers; dev dependency, no CLI JavaScript in browser |
+| @base-ui/react                | 1.7.0   | MIT        | Button and Tooltip primitives; imported through component subpaths                                |
+| Tailwind CSS / PostCSS plugin | 4.3.3   | MIT        | Build-time utility generation; emitted CSS only                                                   |
+| class-variance-authority      | 0.7.1   | Apache-2.0 | Generated Button variants; small client utility                                                   |
+| clsx                          | 2.1.1   | MIT        | Generated class composition utility                                                               |
+| tailwind-merge                | 3.6.0   | MIT        | Generated class conflict resolution; client code                                                  |
+| lucide-react                  | 1.34.0  | ISC        | One named arrow icon; no icon gallery imported                                                    |
+| tw-animate-css                | 1.4.0   | MIT        | Tooltip CSS animations; global reduced-motion override                                            |
+| Geist font assets             | 1.7.2   | OFL-1.1    | Two local variable WOFF2 files, 141020 bytes total; no runtime package or external font requests  |
 
 The CLI help was inspected before initialization; this version accepts `--base base`, not the older `base-ui` flag. Commands used:
 
@@ -59,38 +61,38 @@ Init's Google Fonts import and circular `--font-sans` token were replaced by loc
 
 All packages below are development dependencies; none is imported by the production application.
 
-| Dependency | Version | License | Purpose |
-| --- | --- | --- | --- |
-| ESLint | 9.39.5 | MIT | Compatible lint runtime for the current Next plugins; see limitation below |
-| eslint-config-next | 16.3.3 | MIT | Framework, accessibility, React, and TypeScript lint rules |
-| Prettier | 3.9.6 | MIT | Code/config formatting |
-| Vitest / coverage-v8 | 4.1.11 | MIT | Exclusive lightweight projects and optional coverage; same version |
-| Vite (transitive, locked) | 8.2.2 | MIT | Vitest transformation; not the production Next bundler |
-| jsdom | 30.0.1 | MIT | Component environment only; compatible with Node 24.18 |
-| Testing Library React / DOM | 16.3.3 / 10.4.1 | MIT | Composition semantics and rendering |
-| Testing Library user-event | 14.6.6 | MIT | Keyboard interaction in jsdom |
-| Testing Library jest-dom | 7.0.1 | MIT | DOM assertions |
-| unrs-resolver (transitive, locked) | 1.12.2 | MIT | ESLint import resolution; reviewed native-package postinstall explicitly allowed |
+| Dependency                         | Version         | License | Purpose                                                                          |
+| ---------------------------------- | --------------- | ------- | -------------------------------------------------------------------------------- |
+| ESLint                             | 9.39.5          | MIT     | Compatible lint runtime for the current Next plugins; see limitation below       |
+| eslint-config-next                 | 16.3.3          | MIT     | Framework, accessibility, React, and TypeScript lint rules                       |
+| Prettier                           | 3.9.6           | MIT     | Code/config formatting                                                           |
+| Vitest / coverage-v8               | 4.1.11          | MIT     | Exclusive lightweight projects and optional coverage; same version               |
+| Vite (transitive, locked)          | 8.2.2           | MIT     | Vitest transformation; not the production Next bundler                           |
+| jsdom                              | 30.0.1          | MIT     | Component environment only; compatible with Node 24.18                           |
+| Testing Library React / DOM        | 16.3.3 / 10.4.1 | MIT     | Composition semantics and rendering                                              |
+| Testing Library user-event         | 14.6.6          | MIT     | Keyboard interaction in jsdom                                                    |
+| Testing Library jest-dom           | 7.0.1           | MIT     | DOM assertions                                                                   |
+| unrs-resolver (transitive, locked) | 1.12.2          | MIT     | ESLint import resolution; reviewed native-package postinstall explicitly allowed |
 
 **Compatibility limitation:** ESLint 9.39.5 is deprecated upstream. ESLint 10.9.1 was actually tried and rejected: the Next-resolved import/jsx-a11y/react plugins declare ESLint 9 peer ranges, and `react/display-name` crashes on the removed `context.getFilename` API. Pin the functioning compatible version without suppressing rules or peer checks; reconsider at L13 or when Next's plugin dependencies support ESLint 10. This affects developer tooling, not shipped site code. `pnpm peers check` must remain clean.
 
 ## PDF feasibility (L02-S01)
 
-| Dependency | Version | License | Reason and browser impact |
-| --- | --- | --- | --- |
-| @react-pdf/renderer | 4.9.0 | MIT | Local React document layout and PDF generation; the browser worker imports only this rendering path |
-| pdf-lib | 1.17.1 | MIT | Isolated final-byte post-processing for explicit MediaBox, CropBox, TrimBox, and BleedBox entries |
-| pdfjs-dist | 6.2.108 | Apache-2.0 | Independent content/dimension reader in qualification and local browser viewer in S02; worker asset remains local |
-| React | 19.2.8 | MIT | Matches the website runtime and is required by the renderer |
-| Noto Sans Latin static WOFF | @fontsource/noto-sans 5.3.0 | OFL-1.1 | 20,176-byte local PDF font with fixed checksum; no external request |
+| Dependency                  | Version                     | License    | Reason and browser impact                                                                                         |
+| --------------------------- | --------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------- |
+| @react-pdf/renderer         | 4.9.0                       | MIT        | Local React document layout and PDF generation; the browser worker imports only this rendering path               |
+| pdf-lib                     | 1.17.1                      | MIT        | Isolated final-byte post-processing for explicit MediaBox, CropBox, TrimBox, and BleedBox entries                 |
+| pdfjs-dist                  | 6.2.108                     | Apache-2.0 | Independent content/dimension reader in qualification and local browser viewer in S02; worker asset remains local |
+| React                       | 19.2.8                      | MIT        | Matches the website runtime and is required by the renderer                                                       |
+| Noto Sans Latin static WOFF | @fontsource/noto-sans 5.3.0 | OFL-1.1    | 20,176-byte local PDF font with fixed checksum; no external request                                               |
 
 The raw React-pdf probe emitted only `MediaBox`; `CropBox`, `TrimBox`, and `BleedBox` were absent. That observed gap justifies the narrow `pdf-lib` step. It loads the completed bytes, writes the four page boxes, and enforces the final 20 MiB limit without participating in layout. Font provenance, license text, and checksum are stored beside the asset in `packages/documents/assets/fonts`.
 
 ## Document contracts (L04-S01)
 
-| Dependency | Version | License | Reason and browser impact |
-| --- | --- | --- | --- |
-| Zod | 3.25.76 | MIT | Strict render-request contracts and field-path validation; imported by the document core and tree-shaken with distributed source |
+| Dependency | Version | License | Reason and browser impact                                                                                                        |
+| ---------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Zod        | 3.25.76 | MIT     | Strict render-request contracts and field-path validation; imported by the document core and tree-shaken with distributed source |
 
 Zod is a direct dependency because render requests cross the browser-worker boundary and future template schemas must return the same structured field paths. Version 3.25.76 was already locked transitively through development tooling, but that copy was not a production contract. Promoting the established MIT-licensed version avoids a second copy and preserves the workspace's dependency-age policy without an exception; no runtime network request is introduced.
 
@@ -102,9 +104,9 @@ The asset manifest records exact byte sizes, SHA-256 hashes, license location, s
 
 ## Browser journey (L05-S02)
 
-| Dependency | Version | License | Reason and browser impact |
-| --- | --- | --- | --- |
-| @playwright/test | 1.61.1 | Apache-2.0 | One real Chromium journey verifies the built static site, browser worker, PDF.js preview, and downloaded PDF; test tooling only |
+| Dependency       | Version | License    | Reason and browser impact                                                                                                       |
+| ---------------- | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| @playwright/test | 1.61.1  | Apache-2.0 | One real Chromium journey verifies the built static site, browser worker, PDF.js preview, and downloaded PDF; test tooling only |
 
 The same-day 1.62.1 release was not adopted. Version 1.61.1 satisfies Node 24, the Next.js optional peer range, and the existing supply-chain policy without an exception. Playwright runs with one worker and zero retries against a dedicated loopback static server. Its browser binary and artifacts are development/CI resources and are not shipped to users.
 
@@ -112,19 +114,19 @@ The root E2E scope also declares `pdfjs-dist` 6.2.108 as a development dependenc
 
 ## Vector business-card QR (L05-S03)
 
-| Dependency | Version | License | Reason and browser impact |
-| --- | --- | --- | --- |
-| qrcode | 1.5.4 | MIT | Produces a deterministic module matrix rendered as native React-pdf SVG rectangles; used only by templates that declare QR support |
-| @types/qrcode | 1.5.6 | MIT | Type declarations for the document workspace; development only |
+| Dependency    | Version | License | Reason and browser impact                                                                                                          |
+| ------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| qrcode        | 1.5.4   | MIT     | Produces a deterministic module matrix rendered as native React-pdf SVG rectangles; used only by templates that declare QR support |
+| @types/qrcode | 1.5.6   | MIT     | Type declarations for the document workspace; development only                                                                     |
 
 The primitive renders the matrix itself rather than embedding a generated bitmap or making a network request. It enforces the existing 512-byte payload budget, error-correction level M, a four-module quiet zone, and a minimum module size for the selected card layout. Final-PDF decoding remains a separate visual/QR qualification risk and is not inferred from successful matrix creation.
 
 ## Final-PDF QR qualification (L08-S01)
 
-| Dependency | Version | License | Reason and browser impact |
-| --- | --- | --- | --- |
-| @napi-rs/canvas | 1.0.8 | MIT | Test-only native canvas used by PDF.js to rasterize final PDF bytes in Node; already locked as PDF.js's optional renderer, now declared directly for deterministic strict-workspace imports |
-| jsQR | 1.4.0 | Apache-2.0 | Test-only independent decoder applied to the PDF raster; it is not imported by document or website runtime code |
+| Dependency      | Version | License    | Reason and browser impact                                                                                                                                                                   |
+| --------------- | ------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| @napi-rs/canvas | 1.0.8   | MIT        | Test-only native canvas used by PDF.js to rasterize final PDF bytes in Node; already locked as PDF.js's optional renderer, now declared directly for deterministic strict-workspace imports |
+| jsQR            | 1.4.0   | Apache-2.0 | Test-only independent decoder applied to the PDF raster; it is not imported by document or website runtime code                                                                             |
 
 These development dependencies add no browser payload and do not replace the maintained `qrcode` encoder. The test deliberately crosses encoder, React-pdf SVG output, final PDF post-processing, PDF.js rasterization, and an independent decoding implementation. `@napi-rs/canvas` was already present in the lockfile through PDF.js, so the direct declaration adds one small JavaScript package entry and no second native binary family.
 
@@ -132,12 +134,12 @@ These development dependencies add no browser payload and do not replace the mai
 
 Qualified before adoption on 2026-08-31 from exact npm tarballs:
 
-| Dependency | Version | License | Reason and impact |
-| --- | --- | --- | --- |
-| jsbarcode | 3.12.3 | MIT, Johan Lindell | Public object-output API encodes Code 128 / EAN-13 without invoking a DOM or canvas renderer. No runtime dependencies. The full public entry measures 64,160 bytes minified / 11,186 bytes gzip with the already locked Rolldown 1.2.6, browser platform, ESM output. |
-| @zxing/library | 0.23.0 | Apache-2.0 | Independent final-PDF raster decoder, root development dependency only. Upstream is maintenance-only; the pinned decoder is a test oracle, not a shipped scanner feature. |
-| ts-custom-error | 3.3.1 | MIT | Decoder transitive dependency, no runtime dependencies. Test-only. |
-| @zxing/text-encoding | 0.9.0 | Unlicense OR Apache-2.0 | Optional decoder transitive dependency, no runtime dependencies. Apache-2.0 option reviewed; test-only. |
+| Dependency           | Version | License                 | Reason and impact                                                                                                                                                                                                                                                     |
+| -------------------- | ------- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| jsbarcode            | 3.12.3  | MIT, Johan Lindell      | Public object-output API encodes Code 128 / EAN-13 without invoking a DOM or canvas renderer. No runtime dependencies. The full public entry measures 64,160 bytes minified / 11,186 bytes gzip with the already locked Rolldown 1.2.6, browser platform, ESM output. |
+| @zxing/library       | 0.23.0  | Apache-2.0              | Independent final-PDF raster decoder, root development dependency only. Upstream is maintenance-only; the pinned decoder is a test oracle, not a shipped scanner feature.                                                                                             |
+| ts-custom-error      | 3.3.1   | MIT                     | Decoder transitive dependency, no runtime dependencies. Test-only.                                                                                                                                                                                                    |
+| @zxing/text-encoding | 0.9.0   | Unlicense OR Apache-2.0 | Optional decoder transitive dependency, no runtime dependencies. Apache-2.0 option reviewed; test-only.                                                                                                                                                               |
 
 Exact tarball license texts and manifests were inspected; ZXing ships its Apache license without a separate NOTICE file. Dependency license/copyright files remain in installed packages; redistribution must preserve their notices. No upstream source is copied into the project. JsBarcode's bundled DOM renderer definitions are not called: only its documented object encoding output is consumed. Private encoder subpaths were avoided. The broader bwip-js candidate was not adopted because this public entry covers the two requested formats within the measured budget; no comparative bwip-js bundle benchmark is claimed. The decoder tarball is 1,802,262 bytes; none of it enters production bundles.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -38,6 +38,8 @@ For the authorized beta, configure the Vercel production build with `SITE_URL=ht
 
 Analytics remains disabled unless both `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` and `NEXT_PUBLIC_POSTHOG_HOST=https://eu.i.posthog.com` are configured. The project token is public ingestion configuration, not a personal API credential. Before enabling it, configure the PostHog EU project for Cookieless server hash mode, no person profiles, no autocapture or replay, and discarded IP data. Never add the private Query Read key to this repository or public Vercel project.
 
+Vercel Web Analytics is included independently through the same-origin `@vercel/analytics` integration. Enable Web Analytics for the public Vercel project before promotion. It supplies anonymous page views, daily traffic, country, route, and referrer aggregates without a cookie banner. Keep any Vercel access token used to query those aggregates exclusively in the private dashboard Preview environment.
+
 Static builds emit a canonical URL and sitemap entry for every public page. Without `SITE_URL`, canonicals use the loopback development origin and the complete site emits `noindex, nofollow` plus `Disallow: /`. A publication candidate becomes indexable only when it has an authorized `SITE_URL` and `DOCN_ALLOW_INDEXING=true`. Generated preview assets and development registry paths remain excluded from crawlers. Do not enable indexing merely to test a preview deployment.
 
 Long cache lifetimes for hashed assets and immutable versioned registry files; current HTML/catalog can be revalidated. Registry JSON/public archives needed by consumers are accessible without a session; configure CORS where documented use requires it, not as general permission for exfiltration.

--- a/docs/adr/0005-privacy-minimal-analytics.md
+++ b/docs/adr/0005-privacy-minimal-analytics.md
@@ -1,4 +1,4 @@
-# ADR 0005 — Privacy-minimal product analytics
+# ADR 0005 — Privacy-minimal hybrid analytics
 
 Status: accepted on 2026-09-04 by explicit maintainer direction.
 
@@ -6,11 +6,13 @@ Status: accepted on 2026-09-04 by explicit maintainer direction.
 
 The public beta needs enough aggregate evidence to answer whether docn-ui is used, where visitors discover it, which templates and components attract attention, and which visits reach preview, download, or installation intent.
 
-The existing architecture deliberately had no telemetry. The maintainer requested analytics before the official v1 release and selected PostHog, while also requiring low operational complexity and accepting that the event data is not highly sensitive. The repository remains public, but privileged analytics access must not be public.
+The existing architecture deliberately had no telemetry. The maintainer requested analytics before the official v1 release, while also requiring low operational complexity and accepting that the event data is not highly sensitive. The repository remains public, but privileged analytics access must not be public.
+
+Strict cookieless PostHog events do not retain the request data needed for reliable geography. Vercel Web Analytics is already available on the selected Hobby hosting plan, uses no cookies, exposes country and traffic dimensions, and has a first-party aggregate query API. The two products therefore serve different, complementary purposes.
 
 ## Decision
 
-The public application uses `posthog-js` with a public ingestion-only project token. Its configuration is fixed to:
+The public application uses two bounded sources. Vercel Web Analytics records anonymous page views for traffic, daily trends, countries, entry pages, and referrer hostnames. `posthog-js` records product actions with a public ingestion-only project token and this fixed configuration:
 
 - PostHog EU ingestion;
 - `cookieless_mode: "always"`;
@@ -20,11 +22,13 @@ The public application uses `posthog-js` with a public ingestion-only project to
 - manual page and product events only;
 - a final `before_send` allowlist that removes URLs, titles, referrers, document data, search terms, free-form errors, and person properties.
 
-Page events use coarse route classes rather than full paths. Product events contain only controlled repository identifiers and enums. PostHog project settings must enable Cookieless server hash mode and discard IP data. Country aggregation may be used only if PostHog can derive it before discarding IP data; otherwise the private dashboard removes geography rather than retaining IP addresses.
+PostHog page events use coarse route classes rather than full paths. Product events contain only controlled repository identifiers and enums. PostHog project settings must enable Cookieless server hash mode and discard IP data. PostHog geography is not queried. Country aggregation comes only from Vercel's anonymous Web Analytics dataset.
 
-The public token is expected to be visible in the browser and grants ingestion only. No PostHog personal API key is added to this repository or public deployment.
+The public PostHog token is expected to be visible in the browser and grants ingestion only. Vercel's page-view script uses its same-origin framework integration and requires no public credential. No PostHog personal API key or Vercel access token is added to this repository or public deployment.
 
-Privileged query code and the dashboard live in the separate private repository `Osiris-Balonga/docn-ui-analytics`. It uses a server-only Query Read key and is intended for a Vercel Preview Deployment protected by Vercel Authentication. The Hobby-plan production domain is not used for the dashboard.
+Privileged query code and the dashboard live in the separate private repository `Osiris-Balonga/docn-ui-analytics`. It uses a server-only PostHog Query Read key and a server-only Vercel access token, and is intended for a Vercel Preview Deployment protected by Vercel Authentication. The Hobby-plan production domain is not used for the dashboard.
+
+The dashboard labels traffic and product-action sections by source. It must not present a regional conversion rate or another metric that joins individual visitors across providers. Vercel Web Analytics collection stops when the Hobby allowance is exhausted rather than creating overage charges, and its reporting window is limited by the active plan. Counts may differ because the providers use separate anonymous identifiers, collection paths, and blocker behavior.
 
 ## Approved events
 
@@ -48,6 +52,8 @@ The Content Security Policy adds only `https://eu.i.posthog.com` to `connect-src
 
 - Analytics remains optional: missing or invalid public variables disable it without affecting the product.
 - The dashboard can answer aggregate product questions without a database or custom authentication.
+- Vercel supplies anonymous country and traffic data; PostHog supplies allowlisted product actions.
+- Cross-provider visitor joins and regional conversion metrics are deliberately unavailable.
 - Cookieless counts are suitable for directional product analysis, not durable user identity or retention cohorts.
 - Browser blockers can reduce counts; no reverse proxy is added in V1.
 - This maintainer-directed pre-release change does not authorize the official v1 tag, release, `dev` to `main` merge, or indexing.

--- a/docs/implementation/status.json
+++ b/docs/implementation/status.json
@@ -22,8 +22,8 @@
     "projectLanguage": "en",
     "conversationLanguage": "fr",
     "analytics": {
-      "provider": "PostHog EU",
-      "publicInstrumentation": "cookieless allowlisted events",
+      "provider": "Vercel Web Analytics and PostHog EU",
+      "publicInstrumentation": "cookieless page views and allowlisted product events",
       "privateDashboardRepository": "Osiris-Balonga/docn-ui-analytics",
       "authorizedAt": "2026-09-04",
       "releaseAuthorizationUnchanged": true

--- a/docs/qa/ANALYTICS-HYBRID.md
+++ b/docs/qa/ANALYTICS-HYBRID.md
@@ -1,0 +1,22 @@
+# Hybrid analytics evidence
+
+Date: 2026-09-04
+
+Scope: maintainer-directed extension of the pre-release analytics decision on `feat/vercel-web-analytics`. This evidence does not change L16 release authorization or state.
+
+## Contract
+
+- Vercel Web Analytics records anonymous page views and supplies traffic, country, route, and referrer aggregates.
+- PostHog retains the existing cookieless allowlist for product actions.
+- No Vercel access token is present in the public repository, browser bundle, or public Vercel project.
+- The private dashboard does not join visitors across providers or derive regional conversion rates.
+- Hobby usage cannot create Web Analytics overage charges; collection pauses when the included allowance is exhausted.
+
+## Verification
+
+- `corepack pnpm@11.24.0 --filter @docn-ui/www typecheck`: passed.
+- `corepack pnpm@11.24.0 lint`: passed with zero warnings.
+- `corepack pnpm@11.24.0 build`: passed, including 18 template PDFs, 21 preview pages, 62 registry items, 28 component PDFs, three theme PDFs, and the complete static Next.js export.
+- The emitted layout chunk containing the analytics adapter is 6,376 raw bytes and 2,715 gzip bytes in total. This is a containing-chunk measurement, not an isolated incremental delta.
+- The Vercel project Analytics view was observed enabled on 2026-09-04 and exposes the required Pages, Referrers, and Countries dimensions. No billing upgrade or payment method was requested.
+- No deployment, production promotion, official release, or `dev` to `main` merge was performed.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       '@docn-ui/documents':
         specifier: workspace:*
         version: link:../../packages/documents
+      '@vercel/analytics':
+        specifier: 2.0.1
+        version: 2.0.1(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -1548,6 +1551,35 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vitest/coverage-v8@4.1.11':
     resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
@@ -5708,6 +5740,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@vercel/analytics@2.0.1(next@16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    optionalDependencies:
+      next: 16.3.3(@babel/core@7.29.7(supports-color@7.2.0))(@playwright/test@1.61.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
 
   '@vitest/coverage-v8@4.1.11(vitest@4.1.11)':
     dependencies:


### PR DESCRIPTION
## Summary

- add cookieless Vercel Web Analytics page-view collection
- retain PostHog for allowlisted product actions
- document the hybrid provider and privacy boundary
- record local build, lint, typecheck, and bundle evidence

## Verification

- corepack pnpm@11.24.0 --filter @docn-ui/www typecheck
- corepack pnpm@11.24.0 lint
- corepack pnpm@11.24.0 build

## Boundaries

- no access token is shipped to the public application
- no production promotion, release, indexing change, or dev-to-main merge
- no visitor-level joins between Vercel and PostHog