### PR TITLE
fix(deploy): support Vercel source archives

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "dev": "pnpm generate:templates && pnpm generate:registry && pnpm --filter @docn-ui/www dev",
     "build": "corepack pnpm@11.24.0 generate:templates && corepack pnpm@11.24.0 generate:registry && corepack pnpm@11.24.0 --filter @docn-ui/www build && node tooling/testing/build-fingerprint.mjs write",
+    "build:vercel": "corepack pnpm@11.24.0 generate:templates && corepack pnpm@11.24.0 generate:registry && corepack pnpm@11.24.0 --filter @docn-ui/www build",
     "build:preview": "node tooling/deployment/build-preview.mjs",
     "generate:templates": "node tooling/templates/generate.mjs",
     "verify:templates": "node tooling/templates/generate.mjs --check",

--- a/tooling/deployment/static-policy.test.ts
+++ b/tooling/deployment/static-policy.test.ts
@@ -51,7 +51,7 @@ describe("portable static hosting policy", () => {
       );
 
     expect(config.installCommand).toContain("pnpm@11.24.0");
-    expect(config.buildCommand).toBe("corepack pnpm@11.24.0 build");
+    expect(config.buildCommand).toBe("corepack pnpm@11.24.0 build:vercel");
     expect(config.outputDirectory).toBe("apps/www/out");
     expect(headersFor("/(.*)")["Cache-Control"]).toBe(
       cacheControlForPath("/docs/installation/index.html"),

--- a/tooling/docs/generate.mjs
+++ b/tooling/docs/generate.mjs
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { resolve, posix } from "node:path";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { relative, resolve, posix } from "node:path";
 import { fileURLToPath } from "node:url";
 import { execFileSync } from "node:child_process";
 import { createCanvas } from "@napi-rs/canvas";
@@ -16,27 +16,56 @@ const root = fileURLToPath(new URL("../..", import.meta.url));
 const publicRoot = resolve(root, "apps/www/public");
 const indexPath = resolve(root, ".artifacts/docs/catalog.json");
 const digest = (bytes) => createHash("sha256").update(bytes).digest("hex");
-const inputs = execFileSync(
-  "git",
-  [
-    "ls-files",
-    "-z",
-    "--cached",
-    "--others",
-    "--exclude-standard",
-    "--",
-    "packages/documents",
-    "tooling/docs",
-    "tooling/registry",
-    "pnpm-lock.yaml",
-  ],
-  { cwd: root },
-)
-  .toString()
-  .split("\0")
-  .filter(Boolean)
-  .filter((file) => existsSync(resolve(root, file)))
-  .sort();
+const inputPaths = [
+  "packages/documents",
+  "tooling/docs",
+  "tooling/registry",
+  "pnpm-lock.yaml",
+];
+
+async function collectFiles(path) {
+  const absolutePath = resolve(root, path);
+  const entries = await readdir(absolutePath, { withFileTypes: true }).catch(
+    () => null,
+  );
+  if (!entries) return existsSync(absolutePath) ? [path] : [];
+  const files = await Promise.all(
+    entries.map((entry) =>
+      entry.isDirectory()
+        ? collectFiles(resolve(path, entry.name))
+        : entry.isFile()
+          ? [
+              relative(root, resolve(absolutePath, entry.name)).replaceAll(
+                "\\",
+                "/",
+              ),
+            ]
+          : [],
+    ),
+  );
+  return files.flat();
+}
+
+const inputs = existsSync(resolve(root, ".git"))
+  ? execFileSync(
+      "git",
+      [
+        "ls-files",
+        "-z",
+        "--cached",
+        "--others",
+        "--exclude-standard",
+        "--",
+        ...inputPaths,
+      ],
+      { cwd: root },
+    )
+      .toString()
+      .split("\0")
+      .filter(Boolean)
+      .filter((file) => existsSync(resolve(root, file)))
+      .sort()
+  : (await Promise.all(inputPaths.map(collectFiles))).flat().sort();
 const hash = createHash("sha256");
 for (const file of inputs) {
   hash.update(file);

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": null,
   "installCommand": "corepack pnpm@11.24.0 install --frozen-lockfile",
-  "buildCommand": "corepack pnpm@11.24.0 build",
+  "buildCommand": "corepack pnpm@11.24.0 build:vercel",
   "outputDirectory": "apps/www/out",
   "trailingSlash": true,
   "headers": [


### PR DESCRIPTION
## Summary
- fall back to filesystem discovery when Vercel builds without Git metadata
- use a hosted build script that omits the local Git fingerprint

## Verification
- formatting, ESLint, and TypeScript checks
- production-equivalent static build